### PR TITLE
fix: fix null input schema for 3 tools causing API validation errors

### DIFF
--- a/internal/tools/list_automate_sessions.go
+++ b/internal/tools/list_automate_sessions.go
@@ -53,5 +53,6 @@ func RegisterListAutomateSessionsTool(server *mcp.Server, client *caido.Client) 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_automate_sessions",
 		Description: `List fuzzing sessions. Returns id/name/createdAt.`,
+		InputSchema: map[string]any{"type": "object"},
 	}, listAutomateSessionsHandler(client))
 }

--- a/internal/tools/list_replay_sessions.go
+++ b/internal/tools/list_replay_sessions.go
@@ -55,5 +55,6 @@ func RegisterListReplaySessionsTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_replay_sessions",
 		Description: `List replay sessions. Returns id/name.`,
+		InputSchema: map[string]any{"type": "object"},
 	}, listReplaySessionsHandler(client))
 }

--- a/internal/tools/list_scopes.go
+++ b/internal/tools/list_scopes.go
@@ -55,5 +55,6 @@ func RegisterListScopesTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_scopes",
 		Description: `List scopes. Returns name/allowlist/denylist.`,
+		InputSchema: map[string]any{"type": "object"},
 	}, listScopesHandler(client))
 }


### PR DESCRIPTION
3 Caido MCP tools (list_automate_sessions, list_replay_sessions, list_scopes) have no input parameters (empty struct). The Go SDK automatically generates their JSON   
schema, but for empty structs it generates null instead of a valid schema object.                                                                                      
                                                                                                                                                                       
Anthropic's API requires a valid JSON schema object (minimum: {"type": "object"}). When it receives null, it rejects the request with:                                 
"None is not of type 'object'"                                                                                                                                         

Fix:

Added InputSchema: map[string]any{"type": "object"} to all 3 tools:
```go
mcp.AddTool(server, &mcp.Tool{
    Name:        "caido_list_automate_sessions",
    Description: `List fuzzing sessions...`,
    InputSchema: map[string]any{"type": "object"},  // <-- ADDED
}, handler)
```
This explicitly tells the API: "this tool accepts an empty object {} as input."