### PR TITLE
perf: avoid fetching raw payloads unless needed

### DIFF
--- a/internal/caido/client.go
+++ b/internal/caido/client.go
@@ -100,6 +100,24 @@ func (c *Client) GetRequest(ctx context.Context, id string) (*Request, error) {
 	return resp.Request, nil
 }
 
+// GetRequestMetadata fetches a single request by ID without requesting large raw
+// request/response payloads. Useful for metadata-only tool calls.
+func (c *Client) GetRequestMetadata(ctx context.Context, id string) (*Request, error) {
+	req := graphql.NewRequest(RequestMetadataQuery)
+	req.Var("id", id)
+
+	var resp GetRequestResult
+	if err := c.doRequest(ctx, req, &resp); err != nil {
+		return nil, fmt.Errorf("failed to get request: %w", err)
+	}
+
+	if resp.Request == nil {
+		return nil, fmt.Errorf("request not found: %s", id)
+	}
+
+	return resp.Request, nil
+}
+
 // StartAuthenticationFlowResult is the response from starting auth flow
 type StartAuthenticationFlowResult struct {
 	StartAuthenticationFlow struct {
@@ -338,9 +356,9 @@ func (c *Client) CreateReplaySession(ctx context.Context) (*ReplaySession, error
 
 // StartReplayTaskInput is the input for starting a replay task
 type StartReplayTaskInput struct {
-	Connection ConnectionInfoInput       `json:"connection"`
-	Raw        string                    `json:"raw"` // Base64 encoded request
-	Settings   ReplayEntrySettingsInput  `json:"settings"`
+	Connection ConnectionInfoInput      `json:"connection"`
+	Raw        string                   `json:"raw"` // Base64 encoded request
+	Settings   ReplayEntrySettingsInput `json:"settings"`
 }
 
 // ConnectionInfoInput is the input for connection info
@@ -360,8 +378,8 @@ type ReplayEntrySettingsInput struct {
 
 // PlaceholderInput is the input for placeholders
 type PlaceholderInput struct {
-	InputRange  []int  `json:"inputRange"`
-	OutputRange []int  `json:"outputRange"`
+	InputRange    []int    `json:"inputRange"`
+	OutputRange   []int    `json:"outputRange"`
 	Preprocessors []string `json:"preprocessors"`
 }
 

--- a/internal/caido/queries.go
+++ b/internal/caido/queries.go
@@ -32,25 +32,46 @@ query Requests($first: Int, $after: String, $filter: HTTPQL) {
 
 	// RequestQuery is the GraphQL query for getting a single request by ID
 	RequestQuery = `
-query Request($id: ID!) {
-  request(id: $id) {
-    id
-    method
-    host
-    port
-    path
-    query
-    isTls
-    raw
-    createdAt
-    response {
-      statusCode
-      raw
-      roundtripTime
-    }
-  }
-}
-`
+	query Request($id: ID!) {
+	  request(id: $id) {
+	    id
+	    method
+	    host
+	    port
+	    path
+	    query
+	    isTls
+	    raw
+	    createdAt
+	    response {
+	      statusCode
+	      raw
+	      roundtripTime
+	    }
+	  }
+	}
+	`
+
+	// RequestMetadataQuery is a slimmer version of RequestQuery that avoids fetching
+	// potentially large raw request/response payloads when they are not needed.
+	RequestMetadataQuery = `
+	query RequestMetadata($id: ID!) {
+	  request(id: $id) {
+	    id
+	    method
+	    host
+	    port
+	    path
+	    query
+	    isTls
+	    createdAt
+	    response {
+	      statusCode
+	      roundtripTime
+	    }
+	  }
+	}
+	`
 
 	// StartAuthenticationFlowMutation initiates the OAuth flow
 	StartAuthenticationFlowMutation = `
@@ -124,39 +145,37 @@ query AutomateSession($id: ID!) {
 
 	// AutomateEntryQuery gets a single Automate entry with fuzz results
 	AutomateEntryQuery = `
-query AutomateEntry($id: ID!, $first: Int, $after: String) {
-  automateEntry(id: $id) {
-    id
-    name
-    createdAt
-    requests(first: $first, after: $after) {
-      edges {
-        cursor
-        node {
-          sequenceId
-          automateEntryId
-          payloads {
-            raw
-            position
-          }
-          error
-          request {
-            id
-            method
-            host
-            port
-            path
-            query
-            isTls
-            raw
-            response {
-              statusCode
-              raw
-              roundtripTime
-            }
-          }
-        }
-      }
+	query AutomateEntry($id: ID!, $first: Int, $after: String) {
+	  automateEntry(id: $id) {
+	    id
+	    name
+	    createdAt
+	    requests(first: $first, after: $after) {
+	      edges {
+	        cursor
+	        node {
+	          sequenceId
+	          automateEntryId
+	          payloads {
+	            raw
+	            position
+	          }
+	          error
+	          request {
+	            id
+	            method
+	            host
+	            port
+	            path
+	            query
+	            isTls
+	            response {
+	              statusCode
+	              roundtripTime
+	            }
+	          }
+	        }
+	      }
       pageInfo {
         hasNextPage
         endCursor


### PR DESCRIPTION
## What
- Add RequestMetadataQuery (no request.raw/response.raw) + Client.GetRequestMetadata
- caido_get_request selects metadata query unless include requests requestHeaders/requestBody/responseHeaders/responseBody
- Slim AutomateEntryQuery to stop fetching request.raw/response.raw (tool never returns them)

## Why (payload/latency)
- Metadata-only caido_get_request previously downloaded + unmarshaled base64 raw bodies it did not return
- This can reduce GraphQL response size from tens/hundreds of KB (or more) to ~1KB for metadata-only calls, improving latency and lowering memory/GC pressure
- If responses are 200 KB to 1 MB, payload reduction is often 100x to 1000x, and latency savings can be hundreds of ms in worse cases.
- caido_get_automate_entry savings scale with limit: avoids N * (request.raw + response.raw) payload per call

## Safety
- No behavior change for callers: when include asks for bodies/headers, the server still uses the full raw query
- go test ./... and go vet ./... clean
