### PR TITLE
fix: surface token refresh errors and fail fast on poll errors

### DIFF
--- a/internal/caido/client.go
+++ b/internal/caido/client.go
@@ -70,7 +70,11 @@ func (c *Client) doRequest(
 	resp interface{},
 ) error {
 	if c.refreshFn != nil {
-		if newToken, err := c.refreshFn(ctx); err == nil && newToken != "" {
+		newToken, err := c.refreshFn(ctx)
+		if err != nil {
+			return err
+		}
+		if newToken != "" {
 			c.tokenMu.Lock()
 			c.token = newToken
 			c.tokenMu.Unlock()

--- a/internal/tools/send_request.go
+++ b/internal/tools/send_request.go
@@ -69,7 +69,7 @@ func pollForResponse(
 
 		session, err := client.GetReplaySession(ctx, sessionID)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("polling failed: %w", err)
 		}
 
 		if session.ActiveEntry == nil {
@@ -83,7 +83,7 @@ func pollForResponse(
 
 		entry, err := client.GetReplayEntry(ctx, session.ActiveEntry.ID)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("polling failed: %w", err)
 		}
 
 		if entry.Request != nil && entry.Request.Response != nil {


### PR DESCRIPTION
## Summary

- **`doRequest` swallowed refresh errors**: when `refreshFn` returned an error (e.g. expired refresh token, Caido unreachable during refresh), the error was silently dropped and the request proceeded with the stale token — producing a confusing GraphQL auth error instead of a clear message. Now the error is returned immediately.
- **`pollForResponse` masked persistent errors**: `GetReplaySession` and `GetReplayEntry` errors were always retried, causing any persistent error (deleted session, network failure) to burn through all 20 retries and return a misleading "timed out" message after 10 seconds. Both now fail fast and return the underlying error.