### PR TITLE
perf: check poll immediately before first sleep

### DIFF
--- a/internal/tools/send_request.go
+++ b/internal/tools/send_request.go
@@ -61,33 +61,25 @@ func pollForResponse(
 	previousEntryID string,
 ) (*caido.ReplayEntry, error) {
 	for i := 0; i < pollMaxRetries; i++ {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(pollInterval):
-		}
-
 		session, err := client.GetReplaySession(ctx, sessionID)
 		if err != nil {
 			return nil, fmt.Errorf("polling failed: %w", err)
 		}
 
-		if session.ActiveEntry == nil {
-			continue
+		if session.ActiveEntry != nil && session.ActiveEntry.ID != previousEntryID {
+			entry, err := client.GetReplayEntry(ctx, session.ActiveEntry.ID)
+			if err != nil {
+				return nil, fmt.Errorf("polling failed: %w", err)
+			}
+			if entry.Request != nil && entry.Request.Response != nil {
+				return entry, nil
+			}
 		}
 
-		// Skip stale entry from previous request
-		if session.ActiveEntry.ID == previousEntryID {
-			continue
-		}
-
-		entry, err := client.GetReplayEntry(ctx, session.ActiveEntry.ID)
-		if err != nil {
-			return nil, fmt.Errorf("polling failed: %w", err)
-		}
-
-		if entry.Request != nil && entry.Request.Response != nil {
-			return entry, nil
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
 		}
 	}
 	return nil, fmt.Errorf("timed out after %ds waiting for response", pollMaxRetries/2)


### PR DESCRIPTION
## Summary

`pollForResponse` previously slept 500ms before the first check, unconditionally. Moving the sleep to the bottom of the loop means fast responses are returned as soon as they're ready — saving up to 500ms on every `send_request` call.