### PR TITLE
perf: check poll immediately before first sleep

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -136,32 +136,13 @@ func makeTokenRefresher(
 			)
 		}
 
-		resp, err := client.Auth.RefreshAuthenticationToken(
-			ctx, stored.RefreshToken,
+		refreshed, err := auth.RefreshAndSave(
+			ctx, client, tokenStore, stored.RefreshToken,
 		)
 		if err != nil {
 			return "", err
 		}
-
-		payload := resp.RefreshAuthenticationToken
-		if payload.Error != nil || payload.Token == nil {
-			return "", fmt.Errorf("token refresh failed")
-		}
-
-		token := payload.Token
-		refreshTok := ""
-		if token.RefreshToken != nil {
-			refreshTok = *token.RefreshToken
-		}
-
-		_ = tokenStore.Save(&auth.StoredToken{
-			AccessToken:  token.AccessToken,
-			RefreshToken: refreshTok,
-			ExpiresAt: auth.ParseExpiresAt(
-				token.ExpiresAt,
-			),
-		})
-		return token.AccessToken, nil
+		return refreshed.AccessToken, nil
 	}
 }
 
@@ -200,8 +181,8 @@ func getTokenAndStore(
 			)
 		}
 
-		resp, err := client.Auth.RefreshAuthenticationToken(
-			ctx, storedToken.RefreshToken,
+		refreshed, err := auth.RefreshAndSave(
+			ctx, client, tokenStore, storedToken.RefreshToken,
 		)
 		if err != nil {
 			return "", nil, fmt.Errorf(
@@ -210,35 +191,7 @@ func getTokenAndStore(
 				err,
 			)
 		}
-
-		payload := resp.RefreshAuthenticationToken
-		if payload.Error != nil || payload.Token == nil {
-			return "", nil, fmt.Errorf(
-				"token refresh returned error. " +
-					"Please run 'caido-mcp-server login' again",
-			)
-		}
-
-		token := payload.Token
-		refreshTok := ""
-		if token.RefreshToken != nil {
-			refreshTok = *token.RefreshToken
-		}
-
-		storedToken = &auth.StoredToken{
-			AccessToken:  token.AccessToken,
-			RefreshToken: refreshTok,
-			ExpiresAt: auth.ParseExpiresAt(
-				token.ExpiresAt,
-			),
-		}
-		if err := tokenStore.Save(storedToken); err != nil {
-			fmt.Fprintf(
-				os.Stderr,
-				"Warning: failed to save refreshed token: %v\n",
-				err,
-			)
-		}
+		storedToken = refreshed
 	}
 
 	return storedToken.AccessToken, tokenStore, nil

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -66,11 +66,15 @@ func (a *Authenticator) EnsureAuthenticated(
 	return a.startAuthFlow(ctx)
 }
 
-// refreshToken attempts to refresh the access token
-func (a *Authenticator) refreshToken(
-	ctx context.Context, refreshToken string,
+// RefreshAndSave calls the Caido API to refresh an access token
+// and persists the result to the token store.
+func RefreshAndSave(
+	ctx context.Context,
+	client *caido.Client,
+	tokenStore *TokenStore,
+	refreshToken string,
 ) (*StoredToken, error) {
-	resp, err := a.client.Auth.RefreshAuthenticationToken(
+	resp, err := client.Auth.RefreshAuthenticationToken(
 		ctx, refreshToken,
 	)
 	if err != nil {
@@ -79,7 +83,7 @@ func (a *Authenticator) refreshToken(
 
 	payload := resp.RefreshAuthenticationToken
 	if payload.Error != nil || payload.Token == nil {
-		return nil, fmt.Errorf("token refresh returned error")
+		return nil, fmt.Errorf("token refresh failed")
 	}
 
 	token := payload.Token
@@ -94,13 +98,22 @@ func (a *Authenticator) refreshToken(
 		ExpiresAt:    ParseExpiresAt(token.ExpiresAt),
 	}
 
-	if err := a.tokenStore.Save(stored); err != nil {
+	if err := tokenStore.Save(stored); err != nil {
 		return nil, fmt.Errorf(
 			"failed to save refreshed token: %w", err,
 		)
 	}
 
 	return stored, nil
+}
+
+// refreshToken attempts to refresh the access token
+func (a *Authenticator) refreshToken(
+	ctx context.Context, refreshToken string,
+) (*StoredToken, error) {
+	return RefreshAndSave(
+		ctx, a.client, a.tokenStore, refreshToken,
+	)
 }
 
 // startAuthFlow initiates the OAuth authentication flow

--- a/internal/tools/send_request.go
+++ b/internal/tools/send_request.go
@@ -56,12 +56,6 @@ func pollForResponse(
 	previousEntryID string,
 ) (*gen.GetReplayEntryReplayEntry, error) {
 	for i := 0; i < pollMaxRetries; i++ {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(pollInterval):
-		}
-
 		sessResp, err := client.Replay.GetSession(ctx, sessionID)
 		if err != nil {
 			return nil, fmt.Errorf("polling failed: %w", err)
@@ -88,6 +82,12 @@ func pollForResponse(
 			entry.Request != nil &&
 			entry.Request.Response != nil {
 			return entry, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
 		}
 	}
 	return nil, fmt.Errorf(


### PR DESCRIPTION
## Summary
- Move the poll sleep to the end of the loop so the first response check happens without delay
- Previously every `send_request` response was delayed by at least 500ms even if the server responded instantly