### PR TITLE
fix: normalize literal \r\n escape sequences in send_request

### DIFF
--- a/internal/tools/send_request.go
+++ b/internal/tools/send_request.go
@@ -151,7 +151,9 @@ func sendRequestHandler(
 		}
 
 		// Normalize line endings
-		raw := strings.ReplaceAll(input.Raw, "\r\n", "\n")
+		// Handle literal \r\n escape sequences that LLMs commonly produce
+		raw := strings.ReplaceAll(input.Raw, `\r\n`, "\n")
+		raw = strings.ReplaceAll(raw, "\r\n", "\n")
 		raw = strings.ReplaceAll(raw, "\n", "\r\n")
 		if !strings.HasSuffix(raw, "\r\n\r\n") {
 			if strings.HasSuffix(raw, "\r\n") {


### PR DESCRIPTION
## Summary

- LLMs commonly produce literal `\r\n` text (backslash-r-backslash-n) when constructing raw HTTP requests via MCP tool parameters
- The JSON/MCP transport passes these as 4-character sequences (`\`, `r`, `\`, `n`) rather than actual CR+LF bytes (0x0D 0x0A)
- This causes the server to send malformed HTTP requests, resulting in `400 Bad Request` responses from target servers

The fix adds one line to convert literal `\r\n` escape sequences to actual newlines before the existing CRLF normalization logic.

## Test plan

- [x] Send request with literal `\r\n` in raw parameter → previously returned 400, now returns valid response
- [x] Send request with actual newlines → still works as before (no regression)
- [x] Verified fix in built binary against live target


🤖 Generated with [Claude Code](https://claude.com/claude-code)