### PR TITLE
fix: resolve token verification failure due to HTTPQL type mismatch

### DIFF
--- a/cmd/mcp/login.go
+++ b/cmd/mcp/login.go
@@ -59,10 +59,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 
 	// Verify the token works
 	client.SetAccessToken(token)
-	one := 1
-	_, err = client.Requests.List(
-		ctx, &caido.ListRequestsOptions{First: &one},
-	)
+	_, err = client.Projects.List(ctx)
 	if err != nil {
 		return fmt.Errorf(
 			"token verification failed: %w", err,


### PR DESCRIPTION
This PR fixes a bug where the `login` command failed during the token verification step with the GraphQL error: `Variable "filter" cannot be of non-input type "HTTPQL"`.

The verification logic has been updated to use `client.Projects.List()` instead of `client.Requests.List()`. This avoids the problematic `HTTPQL` filter variable while still providing a reliable way to confirm that the access token is valid and the client is correctly authenticated.

Fixes #10