### PR TITLE
fix: adapt list_filters and list_tamper_rules to Caido 0.56 union types (closes #13)

### DIFF
--- a/internal/tools/list_filters.go
+++ b/internal/tools/list_filters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -50,12 +51,29 @@ func listFiltersHandler(
 					ID:     f.Id,
 					Name:   f.Name,
 					Alias:  f.Alias,
-					Clause: f.Clause,
+					Clause: filterPresetClauseToString(f.Clause),
 				},
 			)
 		}
 
 		return nil, output, nil
+	}
+}
+
+// filterPresetClauseToString unwraps the Query union (HTTPQL | StreamQL)
+// returned by the FilterPreset.clause field into a plain query string.
+// Caido 0.56+ exposes `clause` as a union; both variants share a `code`
+// field that holds the raw query expression.
+func filterPresetClauseToString(
+	clause gen.ListFilterPresetsFilterPresetsFilterPresetClauseQuery,
+) string {
+	switch v := clause.(type) {
+	case *gen.ListFilterPresetsFilterPresetsFilterPresetClauseHTTPQL:
+		return v.Code
+	case *gen.ListFilterPresetsFilterPresetsFilterPresetClauseStreamQL:
+		return v.Code
+	default:
+		return ""
 	}
 }
 

--- a/internal/tools/list_tamper_rules.go
+++ b/internal/tools/list_tamper_rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -73,7 +74,7 @@ func listTamperRulesHandler(
 					ID:        r.Id,
 					Name:      r.Name,
 					Enabled:   enabled,
-					Condition: r.Condition,
+					Condition: tamperRuleConditionToString(r.Condition),
 					Sources:   sources,
 				})
 			}
@@ -85,6 +86,28 @@ func listTamperRulesHandler(
 
 		return nil, output, nil
 	}
+}
+
+// tamperRuleConditionToString unwraps the Query union (HTTPQL | StreamQL)
+// returned by the TamperRule.condition field into a plain query string.
+// Returns nil when the rule has no condition. Caido 0.56+ exposes
+// `condition` as a union; both variants share a `code` field.
+func tamperRuleConditionToString(
+	cond *gen.ListTamperRuleCollectionsTamperRuleCollectionsTamperRuleCollectionRulesTamperRuleConditionQuery,
+) *string {
+	if cond == nil {
+		return nil
+	}
+	var s string
+	switch v := (*cond).(type) {
+	case *gen.ListTamperRuleCollectionsTamperRuleCollectionsTamperRuleCollectionRulesTamperRuleConditionHTTPQL:
+		s = v.Code
+	case *gen.ListTamperRuleCollectionsTamperRuleCollectionsTamperRuleCollectionRulesTamperRuleConditionStreamQL:
+		s = v.Code
+	default:
+		return nil
+	}
+	return &s
 }
 
 // RegisterListTamperRulesTool registers the tool


### PR DESCRIPTION
## Summary

Fixes #13 — `caido_list_requests` failing on Caido 0.56.0 with:

```
failed to list requests: input:2: Variable "filter" cannot be of non-input type "HTTPQL"
```

…and two related call-sites that break once the upstream SDK adapts to the new schema.

## Root cause

Caido 0.56 changed three things in its GraphQL schema:

1. The scalar `HTTPQL` became `type HTTPQL { code: String! }` (output object).
2. A new `input HTTPQLInput { code: String! }` is required for filter arguments on `requests`, `interceptEntries`, `automateEntries`, `deleteInterceptEntries`.
3. `FilterPreset.clause` and `TamperRule.condition` are now `union Query = HTTPQL | StreamQL` instead of plain HTTPQL strings.

The first two points are fixed in caido-community/sdk-go ([sdk-go PR](https://github.com/caido-community/sdk-go/pull/4)), which keeps the `*string` filter API stable. The third point requires source-level changes here because `f.Clause` and `r.Condition` change from `string`/`*string` to generated interface types.

## What changed

* `internal/tools/list_filters.go` — adds `filterPresetClauseToString` helper that switches on the union variants (`*HTTPQL`, `*StreamQL`) and returns the `code` payload.
* `internal/tools/list_tamper_rules.go` — adds `tamperRuleConditionToString` helper for the optional condition union; returns nil when the rule has no condition.

The wire-format of the MCP tool output is unchanged: `clause` is still a plain string and `condition` is still `*string`. **No breaking change** for MCP clients.

## Why `list_requests` itself is not touched here

`caido_list_requests` doesn't change at the source level — its filter goes through the SDK, and the SDK update transparently wraps the raw `*string` query into `*HTTPQLInput`. Once the SDK bumps, list_requests starts returning real data instead of the GraphQL error in #13.

## Verification

Built this PR with a local `replace github.com/caido-community/sdk-go => ../sdk-go` pointing at [caido-community/sdk-go#4](https://github.com/caido-community/sdk-go/pull/4) and ran the patched binary against `caido-cli 0.56.0` (`-l 127.0.0.1:7777 --proxy-listen 127.0.0.1:8081 --allow-guests`):

| MCP tool | Upstream `:latest` | This PR + SDK PR |
|---|---|---|
| `caido_list_requests` (limit=3) | `failed to list requests: ... non-input type "HTTPQL"` | ✅ 3 items |
| `caido_list_filters` | same error | ✅ 5 items, each with `clause` populated |
| `caido_list_tamper_rules` | same error | ✅ 1 collection, rule with `condition` populated |

The probe script: drives `initialize` → `notifications/initialized` → `tools/call` over stdio JSON-RPC, parses the `content[0].text` payload of each response.

## Merge plan

1. Merge upstream sdk-go PR ([caido-community/sdk-go#4](https://github.com/caido-community/sdk-go/pull/4)).
2. Cut a new sdk-go release tag (e.g. v0.5.0).
3. Bump `github.com/caido-community/sdk-go` in go.mod here, then merge this PR.

Until step 2 lands, this PR's code compiles only with a local `replace` directive — that's why I am not bumping go.mod in this commit.

## Test plan

- [x] `go build ./...` with SDK fix branch via `replace` succeeds.
- [x] `caido_list_requests` returns data against Caido 0.56.0.
- [x] `caido_list_filters` returns presets with non-empty clause strings.
- [x] `caido_list_tamper_rules` returns rules with their condition strings.
- [x] No regression in other tools (`caido_get_instance`, `caido_list_projects`, `caido_get_request`, `caido_get_sitemap`, `caido_list_findings`, `caido_list_replay_sessions` — all still work, as expected).