### PR TITLE
fix: Caido 0.56 compat - SDK v0.5.0, union types, QueryInput

### DIFF
--- a/cmd/cli/batch.go
+++ b/cmd/cli/batch.go
@@ -224,7 +224,8 @@ func runBatchFile(cmd *cobra.Command, args []string) error {
 
 	var spec batchFileSpec
 	if err := json.Unmarshal(data, &spec); err != nil {
-		return fmt.Errorf("parse %s: %w", args[0], err)
+		return fmt.Errorf("parse %s: %w\nExpected format: {\"base\": {\"url\": \"...\", \"method\": \"GET\", \"headers\": {}}, \"requests\": [{\"label\": \"...\", \"url\": \"...\"}]}",
+			args[0], err)
 	}
 
 	var reqs []replay.BatchRequest
@@ -321,9 +322,9 @@ func executeBatch(
 
 // printTable outputs a terse table of results.
 func printTable(results []replay.BatchResult) {
-	fmt.Printf("%-15s  %6s  %-30s  %8s  %s\n",
+	fmt.Printf("%-40s  %6s  %-25s  %8s  %s\n",
 		"LABEL", "STATUS", "CONTENT-TYPE", "SIZE", "ERROR")
-	fmt.Println(strings.Repeat("-", 80))
+	fmt.Println(strings.Repeat("-", 100))
 
 	for _, r := range results {
 		ct := ""
@@ -345,10 +346,10 @@ func printTable(results []replay.BatchResult) {
 			}
 		}
 
-		fmt.Printf("%-15s  %6d  %-30s  %6dB  %s\n",
-			truncate(r.Label, 15),
+		fmt.Printf("%-40s  %6d  %-25s  %6dB  %s\n",
+			truncate(r.Label, 40),
 			r.StatusCode,
-			truncate(ct, 30),
+			truncate(ct, 25),
 			size,
 			errStr,
 		)

--- a/cmd/cli/client.go
+++ b/cmd/cli/client.go
@@ -76,8 +76,17 @@ func newClient(cmd *cobra.Command) (*caido.Client, error) {
 		if t.RefreshToken == "" {
 			return "", fmt.Errorf("token expired, no refresh token")
 		}
+		// Use a bare client without a token refresher to avoid
+		// infinite recursion: the main client's authTransport
+		// calls this closure, so RefreshAndSave must not go
+		// through the same transport.
+		bareClient, err := caido.NewClient(caido.Options{URL: url})
+		if err != nil {
+			return "", fmt.Errorf("refresh client: %w", err)
+		}
+		bareClient.SetAccessToken(t.AccessToken)
 		stored, err := auth.RefreshAndSave(
-			ctx, client, tokenStore, t.RefreshToken,
+			ctx, bareClient, tokenStore, t.RefreshToken,
 		)
 		if err != nil {
 			return "", err

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Khan/genqlient v0.8.1
-	github.com/caido-community/sdk-go v0.4.0
+	github.com/caido-community/sdk-go v0.5.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/modelcontextprotocol/go-sdk v1.2.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/caido-community/sdk-go v0.4.0 h1:daA41wfi3cxVG74vpI7++hv1YYx4XAOyTwwXrtYyMKo=
-github.com/caido-community/sdk-go v0.4.0/go.mod h1:7O5FNuZJAaXqUNI/DXxuT1KwJZnCKZUFbJ+dbfhZ3hY=
+github.com/caido-community/sdk-go v0.5.0 h1:oU4iwBN4bKvDBsJU6qE8j+laFcyyVHHE2uPll/Q0Ru4=
+github.com/caido-community/sdk-go v0.5.0/go.mod h1:7O5FNuZJAaXqUNI/DXxuT1KwJZnCKZUFbJ+dbfhZ3hY=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/tools/create_tamper_rule.go
+++ b/internal/tools/create_tamper_rule.go
@@ -25,7 +25,7 @@ type createTamperRuleGQLInput struct {
 	CollectionId string         `json:"collectionId"`
 	Name         string         `json:"name"`
 	Section      map[string]any `json:"section"`
-	Condition    *string        `json:"condition,omitempty"`
+	Condition    map[string]any `json:"condition,omitempty"`
 	Sources      []gen.Source   `json:"sources"`
 }
 
@@ -98,12 +98,19 @@ func createTamperRuleHandler(
 			sources = append(sources, gen.Source(s))
 		}
 
+		var cond map[string]any
+		if input.Condition != nil {
+			cond = map[string]any{
+				"HTTPQL": map[string]any{"code": *input.Condition},
+			}
+		}
+
 		vars := &createTamperRuleVars{
 			Input: createTamperRuleGQLInput{
 				CollectionId: input.CollectionID,
 				Name:         input.Name,
 				Section:      section,
-				Condition:    input.Condition,
+				Condition:    cond,
 				Sources:      sources,
 			},
 		}

--- a/internal/tools/list_filters.go
+++ b/internal/tools/list_filters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -50,12 +51,25 @@ func listFiltersHandler(
 					ID:     f.Id,
 					Name:   f.Name,
 					Alias:  f.Alias,
-					Clause: f.Clause,
+					Clause: filterPresetClauseToString(f.Clause),
 				},
 			)
 		}
 
 		return nil, output, nil
+	}
+}
+
+func filterPresetClauseToString(
+	clause gen.ListFilterPresetsFilterPresetsFilterPresetClauseQuery,
+) string {
+	switch v := clause.(type) {
+	case *gen.ListFilterPresetsFilterPresetsFilterPresetClauseHTTPQL:
+		return v.Code
+	case *gen.ListFilterPresetsFilterPresetsFilterPresetClauseStreamQL:
+		return v.Code
+	default:
+		return ""
 	}
 }
 

--- a/internal/tools/list_tamper_rules.go
+++ b/internal/tools/list_tamper_rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -73,7 +74,7 @@ func listTamperRulesHandler(
 					ID:        r.Id,
 					Name:      r.Name,
 					Enabled:   enabled,
-					Condition: r.Condition,
+					Condition: tamperRuleConditionToString(r.Condition),
 					Sources:   sources,
 				})
 			}
@@ -85,6 +86,24 @@ func listTamperRulesHandler(
 
 		return nil, output, nil
 	}
+}
+
+func tamperRuleConditionToString(
+	cond *gen.ListTamperRuleCollectionsTamperRuleCollectionsTamperRuleCollectionRulesTamperRuleConditionQuery,
+) *string {
+	if cond == nil {
+		return nil
+	}
+	var s string
+	switch v := (*cond).(type) {
+	case *gen.ListTamperRuleCollectionsTamperRuleCollectionsTamperRuleCollectionRulesTamperRuleConditionHTTPQL:
+		s = v.Code
+	case *gen.ListTamperRuleCollectionsTamperRuleCollectionsTamperRuleCollectionRulesTamperRuleConditionStreamQL:
+		s = v.Code
+	default:
+		return nil
+	}
+	return &s
 }
 
 // RegisterListTamperRulesTool registers the tool


### PR DESCRIPTION
## Summary
- Bumps `sdk-go` to `v0.5.0` (merged and tagged from #4 on the SDK repo)
- Adapts `list_filters` and `list_tamper_rules` to unwrap the new `Query` union type (cherry-picked from #14 by @szybnev)
- Fixes `create_tamper_rule` which PR #14 missed -- `condition` field changed from `HTTPQL` scalar to `QueryInput` oneOf input
- Includes batch table width fix and token refresh recursion guard from local WIP

Closes #13
Supersedes #14

Credit to @szybnev for identifying the issue and writing both the SDK fix and the initial MCP adapter. This PR incorporates that work plus the `create_tamper_rule` gap fix and SDK version bump.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Live test against Caido 0.56: `caido_list_requests`, `caido_list_filters`, `caido_list_tamper_rules`, `caido_create_tamper_rule`

🤖 Generated with [Claude Code](https://claude.com/claude-code)