### PR TITLE
feat(replay): add per-session cookie jar with auto-inject and persist

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Both share the same auth token, the same Go SDK, and the same codebase.
 | Category | Capabilities |
 |----------|-------------|
 | **Proxy History** | Search requests with HTTPQL, get full request/response details |
-| **Replay** | Send HTTP requests, get response inline (status, headers, body) |
+| **Replay** | Send HTTP requests, get response inline (status, headers, body). Per-session cookie jar auto-persists `Set-Cookie` between calls |
 | **Automate** | Access fuzzing sessions, results, and payloads. Start/pause/resume/cancel tasks |
 | **Findings** | Create, list, delete, and export security findings |
 | **Sitemap** | Browse discovered endpoints |
@@ -47,11 +47,18 @@ Both share the same auth token, the same Go SDK, and the same codebase.
 **Built-in security and performance:**
 
 - Credential redaction - Authorization, Cookie, and API key headers are redacted in tool output
+- Session cookie jar - RFC 6265 jar per replay session; `Set-Cookie` from a response is auto-attached to the next `send_request` against the same session, so authenticated flows (login → wp-admin → action) work without manually copying cookies between calls
 - Input validation - length limits on all string inputs to prevent context flooding
 - Token auto-refresh - expired OAuth tokens refresh mid-session automatically
 - Session reuse - single replay session per server lifetime, no sprawl
 - Body limits - response bodies capped at 2KB by default to save LLM context
 - Minimal tool descriptions - optimized for low token overhead per API call
+
+### Session cookie jar
+
+The `caido_send_request` tool maintains an in-memory `http.CookieJar` per replay session. Cookies set via `Set-Cookie` in any response are stored and auto-injected into subsequent requests targeting the same RFC 6265 domain/path. Pass `useCookieJar: false` to a single call to disable injection (useful for session-fixation testing or to verify auth gates). Use `caido_clear_session_cookies` to wipe a session jar between test runs and `caido_get_session_cookies` to introspect what is stored (cookie values are not returned, only metadata).
+
+The output of `caido_send_request` includes a `cookieJar` block with `injectedCookies` (names sent on this call) and `storedCookies` (names captured from `Set-Cookie`), so the LLM can verify the chain stayed authenticated.
 
 ---
 
@@ -129,15 +136,17 @@ This opens your browser for OAuth authentication and saves the token to `~/.caid
 "What's in scope?"
 ```
 
-### MCP Tools (34)
+### MCP Tools (37)
 
 | Tool | Description |
 |------|-------------|
 | `caido_list_requests` | List requests with HTTPQL filter and pagination |
 | `caido_get_request` | Get request details (metadata, headers, body). 2KB body limit default |
-| `caido_send_request` | Send HTTP request via Replay, returns response inline. Polls up to 10s |
+| `caido_send_request` | Send HTTP request via Replay, returns response inline. Polls up to 10s. Auto-injects session cookies and persists `Set-Cookie` (toggle with `useCookieJar`) |
 | `caido_list_replay_sessions` | List replay sessions |
 | `caido_get_replay_entry` | Get replay entry with response. 2KB body limit default |
+| `caido_clear_session_cookies` | Wipe the in-memory cookie jar for a replay session |
+| `caido_get_session_cookies` | List metadata for cookies stored in a session jar matching a URL (values not returned) |
 | `caido_list_automate_sessions` | List fuzzing sessions |
 | `caido_get_automate_session` | Get session details with entry list |
 | `caido_get_automate_entry` | Get fuzz results and payloads |

--- a/cmd/mcp/serve.go
+++ b/cmd/mcp/serve.go
@@ -97,6 +97,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 	tools.RegisterBatchSendTool(server, client)
 	tools.RegisterListReplaySessionsTool(server, client)
 	tools.RegisterGetReplayEntryTool(server, client)
+	tools.RegisterClearSessionCookiesTool(server, client)
+	tools.RegisterGetSessionCookiesTool(server, client)
 
 	// Findings
 	tools.RegisterListFindingsTool(server, client)

--- a/internal/httputil/raw_request.go
+++ b/internal/httputil/raw_request.go
@@ -1,0 +1,112 @@
+package httputil
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ExtractPath returns the request-target from the start-line of a raw
+// HTTP request. Returns "/" when the start-line cannot be parsed.
+func ExtractPath(raw string) string {
+	idx := strings.Index(raw, "\n")
+	if idx < 0 {
+		return "/"
+	}
+	startLine := strings.TrimSpace(raw[:idx])
+	parts := strings.SplitN(startLine, " ", 3)
+	if len(parts) < 2 {
+		return "/"
+	}
+	target := parts[1]
+	if target == "" {
+		return "/"
+	}
+	return target
+}
+
+// HasHeader reports whether the raw request contains the named header.
+// Comparison is case-insensitive. Body content is not searched.
+func HasHeader(raw, name string) bool {
+	lowerName := strings.ToLower(name)
+	headerEnd := strings.Index(raw, "\r\n\r\n")
+	if headerEnd < 0 {
+		headerEnd = len(raw)
+	}
+	prefix := lowerName + ":"
+	for line := range strings.SplitSeq(raw[:headerEnd], "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// InjectHeader appends a header line at the end of the header block
+// of a raw HTTP request, preserving body and CRLF terminator. The raw
+// input must already be CRLF-normalized via NormalizeCRLF.
+func InjectHeader(raw, name, value string) string {
+	separator := "\r\n\r\n"
+	idx := strings.Index(raw, separator)
+	if idx < 0 {
+		return raw + "\r\n" + name + ": " + value + separator
+	}
+	headers := raw[:idx]
+	rest := raw[idx:]
+	return headers + "\r\n" + name + ": " + value + rest
+}
+
+// ExtractRawSetCookies parses the raw HTTP response and returns
+// http.Cookie pointers from every Set-Cookie header. Returns an empty
+// slice when none are present or the response cannot be parsed.
+func ExtractRawSetCookies(rawResponse []byte) []*http.Cookie {
+	parts := bytes.SplitN(rawResponse, []byte("\r\n\r\n"), 2)
+	if len(parts) == 0 {
+		return nil
+	}
+	headerBlock := parts[0]
+
+	reader := bufio.NewReader(bytes.NewReader(headerBlock))
+	if _, err := reader.ReadString('\n'); err != nil && err != io.EOF {
+		return nil
+	}
+
+	header := http.Header{}
+	for {
+		line, err := reader.ReadString('\n')
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed != "" {
+			if colon := strings.Index(trimmed, ":"); colon > 0 {
+				key := strings.TrimSpace(trimmed[:colon])
+				val := strings.TrimSpace(trimmed[colon+1:])
+				header.Add(key, val)
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	resp := &http.Response{Header: header}
+	return resp.Cookies()
+}
+
+// BuildCookieHeader returns a single Cookie header value built from
+// cookies. Pairs are joined with "; ". Returns an empty string when
+// the slice is empty.
+func BuildCookieHeader(cookies []*http.Cookie) string {
+	if len(cookies) == 0 {
+		return ""
+	}
+	pairs := make([]string, 0, len(cookies))
+	for _, c := range cookies {
+		if c == nil || c.Name == "" {
+			continue
+		}
+		pairs = append(pairs, c.Name+"="+c.Value)
+	}
+	return strings.Join(pairs, "; ")
+}

--- a/internal/httputil/raw_request_test.go
+++ b/internal/httputil/raw_request_test.go
@@ -1,0 +1,109 @@
+package httputil
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestExtractPath_Common(t *testing.T) {
+	cases := map[string]string{
+		"GET /admin?id=1 HTTP/1.1\r\nHost: x\r\n\r\n":  "/admin?id=1",
+		"POST /api/v2 HTTP/1.1\r\nHost: x\r\n\r\nbody": "/api/v2",
+		"GET /\r\nHost: x":                             "/",
+		"":                                             "/",
+		"BROKEN":                                       "/",
+	}
+	for raw, want := range cases {
+		if got := ExtractPath(raw); got != want {
+			t.Errorf("ExtractPath(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestHasHeader_CaseInsensitive(t *testing.T) {
+	raw := "GET / HTTP/1.1\r\nHost: x\r\nCookie: a=1\r\nX-Foo: y\r\n\r\nbody"
+	for _, name := range []string{"cookie", "Cookie", "COOKIE"} {
+		if !HasHeader(raw, name) {
+			t.Errorf("HasHeader(%q) = false, want true", name)
+		}
+	}
+	if HasHeader(raw, "Authorization") {
+		t.Errorf("HasHeader(Authorization) = true, want false")
+	}
+}
+
+func TestHasHeader_BodyContentIgnored(t *testing.T) {
+	raw := "GET / HTTP/1.1\r\nHost: x\r\n\r\nCookie: in-body=true"
+	if HasHeader(raw, "Cookie") {
+		t.Errorf("HasHeader should ignore body content")
+	}
+}
+
+func TestInjectHeader_PreservesBody(t *testing.T) {
+	raw := "POST /login HTTP/1.1\r\nHost: x\r\nContent-Length: 4\r\n\r\ndata"
+	out := InjectHeader(raw, "Cookie", "auth=token")
+
+	if !strings.Contains(out, "\r\nCookie: auth=token\r\n") {
+		t.Fatalf("injected header missing: %q", out)
+	}
+	if !strings.HasSuffix(out, "\r\n\r\ndata") {
+		t.Fatalf("body should remain intact: %q", out)
+	}
+	if !HasHeader(out, "Cookie") {
+		t.Fatalf("HasHeader should now report Cookie present")
+	}
+}
+
+func TestInjectHeader_NoHeaderTerminator(t *testing.T) {
+	raw := "GET / HTTP/1.1\r\nHost: x"
+	out := InjectHeader(raw, "Cookie", "k=v")
+	if !strings.Contains(out, "Cookie: k=v") {
+		t.Errorf("expected injection even without terminator: %q", out)
+	}
+	if !strings.HasSuffix(out, "\r\n\r\n") {
+		t.Errorf("expected terminator appended: %q", out)
+	}
+}
+
+func TestExtractRawSetCookies_Basic(t *testing.T) {
+	raw := []byte("HTTP/1.1 200 OK\r\n" +
+		"Set-Cookie: session=abc; Path=/\r\n" +
+		"Set-Cookie: csrf=xyz; HttpOnly; Path=/\r\n" +
+		"Content-Length: 0\r\n\r\n")
+
+	cookies := ExtractRawSetCookies(raw)
+	if len(cookies) != 2 {
+		t.Fatalf("expected 2 cookies, got %d: %#v", len(cookies), cookies)
+	}
+	gotNames := []string{cookies[0].Name, cookies[1].Name}
+	want := map[string]bool{"session": true, "csrf": true}
+	for _, n := range gotNames {
+		if !want[n] {
+			t.Errorf("unexpected cookie name: %s", n)
+		}
+	}
+}
+
+func TestExtractRawSetCookies_NoCookies(t *testing.T) {
+	raw := []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+	if got := ExtractRawSetCookies(raw); len(got) != 0 {
+		t.Errorf("expected 0 cookies, got %#v", got)
+	}
+}
+
+func TestBuildCookieHeader(t *testing.T) {
+	cookies := []*http.Cookie{
+		{Name: "a", Value: "1"},
+		{Name: "b", Value: "2"},
+		{Name: "", Value: "skip"},
+		nil,
+	}
+	got := BuildCookieHeader(cookies)
+	if got != "a=1; b=2" {
+		t.Errorf("got %q, want %q", got, "a=1; b=2")
+	}
+	if BuildCookieHeader(nil) != "" {
+		t.Errorf("nil slice should return empty string")
+	}
+}

--- a/internal/replay/cookiejar.go
+++ b/internal/replay/cookiejar.go
@@ -1,0 +1,96 @@
+package replay
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"sync"
+)
+
+// SessionCookieStore tracks per-replay-session cookie jars in memory.
+// Each session ID maps to an isolated http.CookieJar that follows
+// RFC 6265 domain/path matching via the standard library.
+type SessionCookieStore struct {
+	mu   sync.Mutex
+	jars map[string]http.CookieJar
+}
+
+// NewSessionCookieStore returns an empty store ready for use.
+func NewSessionCookieStore() *SessionCookieStore {
+	return &SessionCookieStore{jars: make(map[string]http.CookieJar)}
+}
+
+// GetJar returns the existing jar for sessionID or lazily creates one.
+func (s *SessionCookieStore) GetJar(sessionID string) (http.CookieJar, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if jar, ok := s.jars[sessionID]; ok {
+		return jar, nil
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("create cookie jar: %w", err)
+	}
+	s.jars[sessionID] = jar
+	return jar, nil
+}
+
+// Cookies returns cookies that match u for sessionID. Returns nil when
+// the session has no jar yet.
+func (s *SessionCookieStore) Cookies(sessionID string, u *url.URL) []*http.Cookie {
+	if u == nil {
+		return nil
+	}
+	s.mu.Lock()
+	jar, ok := s.jars[sessionID]
+	s.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	return jar.Cookies(u)
+}
+
+// SetCookies merges cookies into the jar for sessionID, creating it if
+// needed. Cookies that fail RFC 6265 attribute checks are silently
+// dropped by the underlying jar.
+func (s *SessionCookieStore) SetCookies(
+	sessionID string, u *url.URL, cookies []*http.Cookie,
+) error {
+	if u == nil || len(cookies) == 0 {
+		return nil
+	}
+	jar, err := s.GetJar(sessionID)
+	if err != nil {
+		return err
+	}
+	jar.SetCookies(u, cookies)
+	return nil
+}
+
+// Clear deletes the jar for sessionID. Returns true when a jar was
+// removed and false when nothing was tracked for that session.
+func (s *SessionCookieStore) Clear(sessionID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.jars[sessionID]; !ok {
+		return false
+	}
+	delete(s.jars, sessionID)
+	return true
+}
+
+// Has reports whether sessionID has any tracked jar (cookies may still
+// be empty if the jar was created and immediately read).
+func (s *SessionCookieStore) Has(sessionID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.jars[sessionID]
+	return ok
+}
+
+// defaultStore is the package-level store used by the MCP tools.
+var defaultStore = NewSessionCookieStore()
+
+// DefaultCookieStore returns the package-level store.
+func DefaultCookieStore() *SessionCookieStore { return defaultStore }

--- a/internal/replay/cookiejar_test.go
+++ b/internal/replay/cookiejar_test.go
@@ -1,0 +1,149 @@
+package replay
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return u
+}
+
+func TestSessionCookieStore_GetJarCreatesOnce(t *testing.T) {
+	s := NewSessionCookieStore()
+
+	jar1, err := s.GetJar("session-A")
+	if err != nil {
+		t.Fatalf("first GetJar: %v", err)
+	}
+	jar2, err := s.GetJar("session-A")
+	if err != nil {
+		t.Fatalf("second GetJar: %v", err)
+	}
+	if jar1 != jar2 {
+		t.Fatalf("expected same jar instance for same sessionID")
+	}
+}
+
+func TestSessionCookieStore_IsolatedBetweenSessions(t *testing.T) {
+	s := NewSessionCookieStore()
+	u := mustURL(t, "https://example.com/")
+
+	if err := s.SetCookies("alice", u, []*http.Cookie{
+		{Name: "auth", Value: "alice-token"},
+	}); err != nil {
+		t.Fatalf("set alice: %v", err)
+	}
+	if err := s.SetCookies("bob", u, []*http.Cookie{
+		{Name: "auth", Value: "bob-token"},
+	}); err != nil {
+		t.Fatalf("set bob: %v", err)
+	}
+
+	aliceCookies := s.Cookies("alice", u)
+	bobCookies := s.Cookies("bob", u)
+
+	if len(aliceCookies) != 1 || aliceCookies[0].Value != "alice-token" {
+		t.Fatalf("alice jar mismatch: %#v", aliceCookies)
+	}
+	if len(bobCookies) != 1 || bobCookies[0].Value != "bob-token" {
+		t.Fatalf("bob jar mismatch: %#v", bobCookies)
+	}
+}
+
+func TestSessionCookieStore_ClearRemovesJar(t *testing.T) {
+	s := NewSessionCookieStore()
+	u := mustURL(t, "https://example.com/")
+
+	if err := s.SetCookies("s1", u, []*http.Cookie{
+		{Name: "k", Value: "v"},
+	}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if !s.Has("s1") {
+		t.Fatalf("expected jar to exist before clear")
+	}
+
+	if !s.Clear("s1") {
+		t.Fatalf("Clear should return true for existing jar")
+	}
+	if s.Has("s1") {
+		t.Fatalf("jar should be gone after clear")
+	}
+	if s.Clear("s1") {
+		t.Fatalf("Clear should return false for missing jar")
+	}
+}
+
+func TestSessionCookieStore_RFC6265PathMatching(t *testing.T) {
+	s := NewSessionCookieStore()
+	u := mustURL(t, "https://example.com/admin/")
+	rootURL := mustURL(t, "https://example.com/")
+
+	cookie := &http.Cookie{
+		Name:   "scoped",
+		Value:  "v",
+		Path:   "/admin",
+		Domain: "example.com",
+	}
+	if err := s.SetCookies("s", u, []*http.Cookie{cookie}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	if got := s.Cookies("s", u); len(got) != 1 {
+		t.Fatalf("expected scoped cookie at /admin/, got %d", len(got))
+	}
+	if got := s.Cookies("s", rootURL); len(got) != 0 {
+		t.Fatalf("scoped cookie should not match /, got %d", len(got))
+	}
+}
+
+func TestSessionCookieStore_ConcurrentAccess(t *testing.T) {
+	s := NewSessionCookieStore()
+	u := mustURL(t, "https://example.com/")
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			cookie := &http.Cookie{
+				Name:  "c",
+				Value: "v",
+			}
+			_ = s.SetCookies("shared", u, []*http.Cookie{cookie})
+			_ = s.Cookies("shared", u)
+		}(i)
+	}
+	wg.Wait()
+
+	if !s.Has("shared") {
+		t.Fatalf("shared jar should exist after concurrent writes")
+	}
+}
+
+func TestSessionCookieStore_EmptyInputsAreNoop(t *testing.T) {
+	s := NewSessionCookieStore()
+
+	if err := s.SetCookies("s", nil, []*http.Cookie{
+		{Name: "k", Value: "v"},
+	}); err != nil {
+		t.Fatalf("nil URL should not error: %v", err)
+	}
+	if s.Has("s") {
+		t.Fatalf("nil URL should not create jar")
+	}
+
+	u := mustURL(t, "https://example.com/")
+	if err := s.SetCookies("s", u, nil); err != nil {
+		t.Fatalf("nil cookies should not error: %v", err)
+	}
+}

--- a/internal/tools/clear_session_cookies.go
+++ b/internal/tools/clear_session_cookies.go
@@ -1,0 +1,62 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/c0tton-fluff/caido-mcp-server/internal/replay"
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ClearSessionCookiesInput selects which session jar to wipe.
+type ClearSessionCookiesInput struct {
+	SessionID string `json:"sessionId,omitempty" jsonschema:"Replay session ID. Omit to target the current default session."`
+}
+
+// ClearSessionCookiesOutput reports the operation outcome.
+type ClearSessionCookiesOutput struct {
+	SessionID string `json:"sessionId"`
+	Cleared   bool   `json:"cleared"`
+	Note      string `json:"note,omitempty"`
+}
+
+// clearSessionCookiesHandler removes the cookie jar tracked for the
+// given session. The next send_request call against that session will
+// start with a fresh, empty jar.
+func clearSessionCookiesHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, ClearSessionCookiesInput) (*mcp.CallToolResult, ClearSessionCookiesOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input ClearSessionCookiesInput,
+	) (*mcp.CallToolResult, ClearSessionCookiesOutput, error) {
+		sessionID, err := replay.GetOrCreateSession(
+			ctx, client, input.SessionID,
+		)
+		if err != nil {
+			return nil, ClearSessionCookiesOutput{}, err
+		}
+
+		cleared := replay.DefaultCookieStore().Clear(sessionID)
+		out := ClearSessionCookiesOutput{
+			SessionID: sessionID,
+			Cleared:   cleared,
+		}
+		if !cleared {
+			out.Note = "no jar tracked for this session"
+		}
+		return nil, out, nil
+	}
+}
+
+// RegisterClearSessionCookiesTool registers caido_clear_session_cookies
+// with the MCP server.
+func RegisterClearSessionCookiesTool(
+	server *mcp.Server, client *caido.Client,
+) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_clear_session_cookies",
+		Description: `Wipe the in-memory cookie jar for a replay session. Use to force re-login flows or recover from poisoned cookie state. Returns sessionId and cleared status.`,
+	}, clearSessionCookiesHandler(client))
+}

--- a/internal/tools/get_session_cookies.go
+++ b/internal/tools/get_session_cookies.go
@@ -1,0 +1,102 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/c0tton-fluff/caido-mcp-server/internal/replay"
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetSessionCookiesInput selects which session jar to inspect.
+type GetSessionCookiesInput struct {
+	SessionID string `json:"sessionId,omitempty" jsonschema:"Replay session ID. Omit to target the current default session."`
+	URL       string `json:"url,omitempty" jsonschema:"URL whose cookies should be returned (RFC 6265 domain/path matching). Required."`
+}
+
+// SessionCookie is the redacted shape returned to the LLM. Cookie
+// values are redacted by default to avoid leaking auth tokens into
+// model context. Use Caido UI for raw values.
+type SessionCookie struct {
+	Name     string `json:"name"`
+	ValueLen int    `json:"valueLen"`
+	Domain   string `json:"domain,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Secure   bool   `json:"secure,omitempty"`
+	HTTPOnly bool   `json:"httpOnly,omitempty"`
+}
+
+// GetSessionCookiesOutput is the response payload.
+type GetSessionCookiesOutput struct {
+	SessionID string          `json:"sessionId"`
+	URL       string          `json:"url"`
+	Cookies   []SessionCookie `json:"cookies"`
+	Count     int             `json:"count"`
+}
+
+// getSessionCookiesHandler returns RFC 6265-matching cookies for a
+// (sessionID, URL) pair. Values are NOT returned, only metadata, to
+// avoid leaking tokens into the LLM context.
+func getSessionCookiesHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetSessionCookiesInput) (*mcp.CallToolResult, GetSessionCookiesOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetSessionCookiesInput,
+	) (*mcp.CallToolResult, GetSessionCookiesOutput, error) {
+		if input.URL == "" {
+			return nil, GetSessionCookiesOutput{}, fmt.Errorf(
+				"url is required for cookie matching",
+			)
+		}
+		u, err := url.Parse(input.URL)
+		if err != nil {
+			return nil, GetSessionCookiesOutput{}, fmt.Errorf(
+				"invalid url: %w", err,
+			)
+		}
+
+		sessionID, err := replay.GetOrCreateSession(
+			ctx, client, input.SessionID,
+		)
+		if err != nil {
+			return nil, GetSessionCookiesOutput{}, err
+		}
+
+		cookies := replay.DefaultCookieStore().Cookies(sessionID, u)
+		out := GetSessionCookiesOutput{
+			SessionID: sessionID,
+			URL:       input.URL,
+			Cookies:   make([]SessionCookie, 0, len(cookies)),
+			Count:     len(cookies),
+		}
+		for _, c := range cookies {
+			if c == nil {
+				continue
+			}
+			out.Cookies = append(out.Cookies, SessionCookie{
+				Name:     c.Name,
+				ValueLen: len(c.Value),
+				Domain:   c.Domain,
+				Path:     c.Path,
+				Secure:   c.Secure,
+				HTTPOnly: c.HttpOnly,
+			})
+		}
+		return nil, out, nil
+	}
+}
+
+// RegisterGetSessionCookiesTool registers caido_get_session_cookies
+// with the MCP server.
+func RegisterGetSessionCookiesTool(
+	server *mcp.Server, client *caido.Client,
+) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_get_session_cookies",
+		Description: `List cookies stored in the session jar that match a URL (RFC 6265). Returns metadata only (name/length/domain/path/flags); values are not exposed to avoid leaking tokens into model context. Use to debug cookie persistence between send_request calls.`,
+	}, getSessionCookiesHandler(client))
+}

--- a/internal/tools/send_request.go
+++ b/internal/tools/send_request.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/c0tton-fluff/caido-mcp-server/internal/httputil"
@@ -16,25 +18,35 @@ import (
 
 // SendRequestInput is the input for the send_request tool
 type SendRequestInput struct {
-	Raw        string `json:"raw" jsonschema:"required,Raw HTTP request including headers and body"`
-	Host       string `json:"host,omitempty" jsonschema:"Target host (overrides Host header)"`
-	Port       int    `json:"port,omitempty" jsonschema:"Target port (default based on TLS)"`
-	TLS        *bool  `json:"tls,omitempty" jsonschema:"Use HTTPS (default true)"`
-	SessionID  string `json:"sessionId,omitempty" jsonschema:"Replay session ID (optional)"`
-	BodyLimit  int    `json:"bodyLimit,omitempty" jsonschema:"Response body byte limit (default 2000)"`
-	BodyOffset int    `json:"bodyOffset,omitempty" jsonschema:"Response body byte offset (default 0)"`
+	Raw          string `json:"raw" jsonschema:"required,Raw HTTP request including headers and body"`
+	Host         string `json:"host,omitempty" jsonschema:"Target host (overrides Host header)"`
+	Port         int    `json:"port,omitempty" jsonschema:"Target port (default based on TLS)"`
+	TLS          *bool  `json:"tls,omitempty" jsonschema:"Use HTTPS (default true)"`
+	SessionID    string `json:"sessionId,omitempty" jsonschema:"Replay session ID (optional)"`
+	BodyLimit    int    `json:"bodyLimit,omitempty" jsonschema:"Response body byte limit (default 2000)"`
+	BodyOffset   int    `json:"bodyOffset,omitempty" jsonschema:"Response body byte offset (default 0)"`
+	UseCookieJar *bool  `json:"useCookieJar,omitempty" jsonschema:"Auto-inject session cookies and persist Set-Cookie (default true). Set false to disable for this call only."`
 }
 
 // SendRequestOutput is the output of the send_request tool
 type SendRequestOutput struct {
-	RequestID   string                  `json:"requestId,omitempty"`
-	EntryID     string                  `json:"entryId,omitempty"`
-	SessionID   string                  `json:"sessionId"`
-	StatusCode  int                     `json:"statusCode,omitempty"`
-	RoundtripMs int                     `json:"roundtripMs,omitempty"`
-	Request     *httputil.ParsedMessage `json:"request,omitempty"`
-	Response    *httputil.ParsedMessage `json:"response,omitempty"`
-	Error       string                  `json:"error,omitempty"`
+	RequestID    string                  `json:"requestId,omitempty"`
+	EntryID      string                  `json:"entryId,omitempty"`
+	SessionID    string                  `json:"sessionId"`
+	StatusCode   int                     `json:"statusCode,omitempty"`
+	RoundtripMs  int                     `json:"roundtripMs,omitempty"`
+	Request      *httputil.ParsedMessage `json:"request,omitempty"`
+	Response     *httputil.ParsedMessage `json:"response,omitempty"`
+	CookieJar    *CookieJarStatus        `json:"cookieJar,omitempty"`
+	Error        string                  `json:"error,omitempty"`
+}
+
+// CookieJarStatus reports cookie-jar activity for a single send.
+type CookieJarStatus struct {
+	Enabled         bool     `json:"enabled"`
+	InjectedCookies []string `json:"injectedCookies,omitempty"`
+	StoredCookies   []string `json:"storedCookies,omitempty"`
+	Skipped         string   `json:"skipped,omitempty"`
 }
 
 // isTaskInProgress checks whether the error from
@@ -52,6 +64,39 @@ func isTaskInProgress(
 	}
 	_, ok := (*errPtr).(*gen.StartReplayTaskStartReplayTaskStartReplayTaskPayloadErrorTaskInProgressUserError)
 	return ok
+}
+
+// buildRequestURL synthesizes the *url.URL targeted by raw, used for
+// RFC 6265 cookie matching against the session jar.
+func buildRequestURL(host string, port int, useTLS bool, raw string) *url.URL {
+	scheme := "http"
+	defaultPort := 80
+	if useTLS {
+		scheme = "https"
+		defaultPort = 443
+	}
+	hostHeader := host
+	if port != 0 && port != defaultPort {
+		hostHeader = fmt.Sprintf("%s:%d", host, port)
+	}
+	target := httputil.ExtractPath(raw)
+	u, err := url.Parse(scheme + "://" + hostHeader + target)
+	if err != nil {
+		return &url.URL{Scheme: scheme, Host: hostHeader, Path: "/"}
+	}
+	return u
+}
+
+// cookiesToNames extracts the Name field from each cookie for output.
+// nil cookies and unnamed entries are skipped.
+func cookiesToNames(cookies []*http.Cookie) []string {
+	names := make([]string, 0, len(cookies))
+	for _, c := range cookies {
+		if c != nil && c.Name != "" {
+			names = append(names, c.Name)
+		}
+	}
+	return names
 }
 
 // sendRequestHandler creates the handler function
@@ -118,6 +163,29 @@ func sendRequestHandler(
 			return nil, SendRequestOutput{}, err
 		}
 
+		// Cookie jar (RFC 6265): inject session cookies into raw when
+		// the user did not already set a Cookie header. Default ON.
+		useJar := true
+		if input.UseCookieJar != nil {
+			useJar = *input.UseCookieJar
+		}
+		jarStatus := &CookieJarStatus{Enabled: useJar}
+		reqURL := buildRequestURL(host, port, useTLS, raw)
+
+		if useJar {
+			if httputil.HasHeader(raw, "Cookie") {
+				jarStatus.Skipped = "explicit Cookie header preserved"
+			} else {
+				cookies := replay.DefaultCookieStore().Cookies(sessionID, reqURL)
+				if len(cookies) > 0 {
+					raw = httputil.InjectHeader(
+						raw, "Cookie", httputil.BuildCookieHeader(cookies),
+					)
+					jarStatus.InjectedCookies = cookiesToNames(cookies)
+				}
+			}
+		}
+
 		// Snapshot current active entry
 		var previousEntryID string
 		sessResp, err := client.Replay.GetSession(ctx, sessionID)
@@ -173,7 +241,10 @@ func sendRequestHandler(
 			}
 		}
 
-		output := SendRequestOutput{SessionID: sessionID}
+		output := SendRequestOutput{
+			SessionID: sessionID,
+			CookieJar: jarStatus,
+		}
 
 		entry, pollErr := replay.PollForEntry(
 			ctx, client, sessionID, previousEntryID,
@@ -211,6 +282,22 @@ func sendRequestHandler(
 					resp.Raw, true, true,
 					input.BodyOffset, bodyLimit,
 				)
+
+				// Persist Set-Cookie back into the session jar.
+				if useJar {
+					decoded, decErr := base64.StdEncoding.DecodeString(resp.Raw)
+					if decErr == nil {
+						setCookies := httputil.ExtractRawSetCookies(decoded)
+						if len(setCookies) > 0 {
+							storeErr := replay.DefaultCookieStore().SetCookies(
+								sessionID, reqURL, setCookies,
+							)
+							if storeErr == nil {
+								jarStatus.StoredCookies = cookiesToNames(setCookies)
+							}
+						}
+					}
+				}
 			}
 		}
 
@@ -224,6 +311,6 @@ func RegisterSendRequestTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_send_request",
-		Description: `Send HTTP request and return response inline. Returns statusCode, headers, body. Polls up to 10s for response. On timeout, returns entryId for follow-up via get_replay_entry.`,
+		Description: `Send HTTP request and return response inline. Returns statusCode, headers, body. Polls up to 10s for response. On timeout, returns entryId for follow-up via get_replay_entry. Session cookies (Set-Cookie) auto-persist between calls sharing the same sessionId; pass useCookieJar:false to disable for a single call.`,
 	}, sendRequestHandler(client))
 }


### PR DESCRIPTION
## Problem

Caido replay sessions are request **collections**, not stateful HTTP clients. `Set-Cookie` headers from a response are not reapplied to subsequent `send_request` calls in the same session, so authenticated flows (login → dashboard → action) require the caller to extract `Set-Cookie` out of band and manually inject a `Cookie` header on every follow-up call.

In practice for an AI assistant driving Caido this means: every authenticated test (WordPress admin, OAuth callback chains, multi-step API flows) needs a sidecar `curl -i` step on the host machine just to capture cookies, defeating the point of having an MCP server in the first place.

## Solution

Add an in-memory `http.CookieJar` per replay session ID, wired into `send_request`:

- **Before send**: if the raw request lacks a `Cookie` header, RFC 6265-matching cookies from the jar are injected for the target URL (computed from `host`/`port`/`tls`/path).
- **After send**: `Set-Cookie` headers from the response are parsed and stored in the jar against the request URL.
- **Opt-out per call**: `useCookieJar: false` skips both injection and persistence for that single send. Preserves the existing flow for session-fixation testing or auth-gate verification where automatic propagation is undesirable.
- **Explicit Cookie wins**: when the caller provides their own `Cookie` header in `raw`, the jar does not overwrite it. The cookieJar status block reports `skipped: "explicit Cookie header preserved"` so the LLM understands what happened.

The `send_request` output now includes a `cookieJar` block:

```json
"cookieJar": {
  "enabled": true,
  "injectedCookies": ["session_id"],
  "storedCookies": ["wordpress_logged_in_xxx", "wordpress_xxx"]
}
```

so the caller can verify the chain stayed authenticated.

## New tools

- `caido_clear_session_cookies` — wipe the jar for a session ID. Useful to force re-login flows or recover from poisoned cookie state.
- `caido_get_session_cookies` — list cookie metadata (name/domain/path/flags/value length) for a session matching a given URL. **Values are not returned** to avoid leaking auth tokens into LLM context — Caido UI remains the source of truth for raw values.

## Tests

`go test ./...` passes. New coverage:

- `cookiejar_test.go` — jar isolation between sessions, RFC 6265 path matching, concurrent access (32 goroutines), `Clear` semantics, nil-input safety.
- `raw_request_test.go` — `ExtractPath`, case-insensitive `HasHeader`, body-content-ignored `HasHeader`, `InjectHeader` body preservation, `ExtractRawSetCookies`, `BuildCookieHeader`.

## Backwards compatibility

- `send_request` continues to accept the same input fields. The new `useCookieJar` field is optional (`*bool`) and defaults to `true`.
- Existing callers that always set `Cookie` manually see no behavior change (the jar detects the explicit header and skips injection).
- Output adds a `cookieJar` field but does not remove or rename any existing fields.

## Smoke validation

Built with `go build -ldflags "-X main.version=v0.4.0-cookiejar" ./cmd/mcp`. Binary boots cleanly via STDIO and emits `notifications/tools/list_changed` for the two new tools alongside the existing 35.

## Real-world driver

Discovered while running [TryHackMe Mr. Robot](https://tryhackme.com/room/mrrobot) end-to-end via Caido MCP: WordPress login → theme-editor.php nonce extract → 404.php PHP backdoor inject → RCE → `/home/robot/password.raw-md5` → SSH → SUID nmap legacy `--interactive` shell escape → root. The four `wordpress_logged_in_*` cookies emitted by `wp-login.php` had to be manually copied via a `curl -i` on the host because the MCP server stripped them between calls. With this patch the same chain runs entirely through `caido_send_request` without external tooling.

## Notes for review

- Jar lookup keys on the *actual* sessionID returned by `replay.GetOrCreateSession`. When the session-busy fallback creates a new session, the jar tied to the old ID is orphaned — same observable behavior as today (cookies were already lost on fallback). Cookie migration across the fallback could be a follow-up; left out here to keep the diff focused.
- Memory: jar map grows unbounded with new session IDs. For long-lived MCP processes this is bounded in practice by the user calling `caido_clear_session_cookies` or restarting. An LRU could be added later if it becomes a problem.
- `caido_get_session_cookies` deliberately omits cookie values to honor the existing `[REDACTED]` policy on Cookie/Set-Cookie headers in `parse.go`.