### PR TITLE
fix(tools): resolve invalid jsonschema tags in filter tools

### DIFF
--- a/internal/tools/create_filter.go
+++ b/internal/tools/create_filter.go
@@ -11,9 +11,9 @@ import (
 )
 
 type CreateFilterInput struct {
-	Name  string `json:"name" jsonschema:"required,description=Name of the filter preset"`
-	Query string `json:"query" jsonschema:"required,description=HTTPQL query string"`
-	Alias string `json:"alias,omitempty" jsonschema:"description=Optional alias for the filter"`
+	Name  string `json:"name" jsonschema:"required,Name of the filter preset"`
+	Query string `json:"query" jsonschema:"required,HTTPQL query string"`
+	Alias string `json:"alias,omitempty" jsonschema:"Optional alias for the filter"`
 }
 
 type CreateFilterOutput struct {

--- a/internal/tools/delete_filter.go
+++ b/internal/tools/delete_filter.go
@@ -9,7 +9,7 @@ import (
 )
 
 type DeleteFilterInput struct {
-	ID string `json:"id" jsonschema:"required,description=ID of the filter preset to delete"`
+	ID string `json:"id" jsonschema:"required,ID of the filter preset to delete"`
 }
 
 type DeleteFilterOutput struct {

--- a/internal/tools/schema_test.go
+++ b/internal/tools/schema_test.go
@@ -51,6 +51,8 @@ var allRegistrations = []struct {
 	{"caido_toggle_tamper_rule", tools.RegisterToggleTamperRuleTool},
 	{"caido_delete_tamper_rule", tools.RegisterDeleteTamperRuleTool},
 	{"caido_list_filters", tools.RegisterListFiltersTool},
+	{"caido_create_filter", tools.RegisterCreateFilterTool},
+	{"caido_delete_filter", tools.RegisterDeleteFilterTool},
 	{"caido_list_hosted_files", tools.RegisterListHostedFilesTool},
 	{"caido_list_tasks", tools.RegisterListTasksTool},
 	{"caido_cancel_task", tools.RegisterCancelTaskTool},


### PR DESCRIPTION
Fixes #21

Corrects the invalid `jsonschema` struct tag syntax in `CreateFilterInput` and `DeleteFilterInput` that was causing `AddTool` to panic on server startup. Also adds validation for both tools in `schema_test.go` to prevent future regressions.