### PR TITLE
Add 33 tools for full Caido coverage and WebSocket history (60 -> 93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.0.0] - 2026-05-27
+
+### Added
+- **WebSocket history (read)** - browse WS traffic like the WebSocket tab in Caido. Implemented via raw GraphQL since the Go SDK does not wrap these queries:
+  - `caido_list_ws_streams` - list WebSocket connections (streams)
+  - `caido_list_ws_messages` - list frames of a stream (direction CLIENT/SERVER, format TEXT/BINARY, decoded body)
+- **Automate (fuzzing) management** - create/rename/delete sessions, enabling full fuzzing workflows from MCP:
+  - `caido_create_automate_session` - seed a session from a request ID or raw HTTP
+  - `caido_rename_automate_session`, `caido_delete_automate_session`
+- **Workflow management** - beyond list/run/toggle:
+  - `caido_get_workflow` - inspect a workflow's node-graph definition
+  - `caido_create_workflow` - create from a JSON definition
+  - `caido_rename_workflow`, `caido_delete_workflow`
+  - `caido_set_workflow_scope` - globalize/localize a workflow
+  - `caido_list_workflow_node_definitions` - list available node building blocks
+- **Plugin management**:
+  - `caido_install_plugin` (url or store manifest ID), `caido_delete_plugin`, `caido_toggle_plugin`
+- **Hosted file management**: `caido_rename_hosted_file`, `caido_delete_hosted_file`
+- **Intercept extensions**:
+  - `caido_get_intercept_entry` - single entry with request/response
+  - `caido_get_intercept_options`, `caido_set_intercept_options` - read/configure proxy interception and scope
+  - `caido_delete_intercept_entry`, `caido_delete_intercept_entries` (HTTPQL filter)
+- **Sitemap extensions**: `caido_get_sitemap_entry`, `caido_clear_sitemap`, `caido_delete_sitemap_entries`
+- **Tamper collections**: `caido_create_tamper_collection`, `caido_delete_tamper_collection`, `caido_get_tamper_rule`
+- **Findings**: `caido_get_finding` (single finding + linked request), `caido_list_finding_reporters`
+- **Replay sessions**: `caido_get_replay_session`, `caido_rename_replay_session`
+- **Requests**: `caido_get_request_metadata` - lightweight metadata without raw bodies
+- **User**: `caido_whoami` - the currently authenticated user
+
+### Changed
+- Tool count: 60 -> 93 (33 new tools)
+- Every Caido SDK mutation/query of practical value for pentesting is now exposed as an MCP tool, plus WebSocket history read access via raw GraphQL
+
 ## [3.0.0] - 2026-05-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 Two ways to interact with your Caido proxy:
 
-- **MCP Server** - expose 60 tools and 4 read-only resources to AI assistants (Claude Code, Cursor, etc.) via the Model Context Protocol
+- **MCP Server** - expose 93 tools and 4 read-only resources to AI assistants (Claude Code, Cursor, etc.) via the Model Context Protocol
 - **CLI** - standalone terminal client for pentesters who prefer the command line
 
 Both share the same auth token, the same Go SDK, and the same codebase.
@@ -141,12 +141,15 @@ This opens your browser for OAuth authentication and saves the token to `~/.caid
 "What's in scope?"
 ```
 
-### MCP Tools (60)
+### MCP Tools (93)
 
 | Tool | Description |
 |------|-------------|
 | `caido_list_requests` | List requests with HTTPQL filter and pagination |
 | `caido_get_request` | Get request details (metadata, headers, body). 2KB body limit default |
+| `caido_get_request_metadata` | Get request metadata (method, url, status, timing) without raw bodies |
+| `caido_list_ws_streams` | List WebSocket connections from history (WebSocket tab) |
+| `caido_list_ws_messages` | List WebSocket frames for a stream (direction/format/body) |
 | `caido_send_request` | Send HTTP request via Replay, returns response inline. Polls up to 10s. Auto-injects session cookies and persists `Set-Cookie` (toggle with `useCookieJar`) |
 | `caido_batch_send` | Send multiple requests in parallel (BAC sweeps, parameter fuzzing, endpoint sweeps). Max 50 per batch |
 | `caido_edit_request` | Modify and resend an existing request. Preserves auth/cookies while changing method, path, headers, or body |
@@ -156,6 +159,8 @@ This opens your browser for OAuth authentication and saves the token to `~/.caid
 | `caido_delete_replay_sessions` | Bulk delete replay sessions by ID |
 | `caido_move_replay_session` | Move a session to a different collection |
 | `caido_get_replay_entry` | Get replay entry with response. 2KB body limit default |
+| `caido_get_replay_session` | Get a replay session (name, collection, active entry, entry count) |
+| `caido_rename_replay_session` | Rename a replay session |
 | `caido_clear_session_cookies` | Wipe the in-memory cookie jar for a replay session |
 | `caido_get_session_cookies` | List metadata for cookies stored in a session jar matching a URL (values not returned) |
 | `caido_list_replay_collections` | List replay session collections |
@@ -166,11 +171,19 @@ This opens your browser for OAuth authentication and saves the token to `~/.caid
 | `caido_get_automate_session` | Get session details with entry list |
 | `caido_get_automate_entry` | Get fuzz results and payloads |
 | `caido_automate_task_control` | Start/pause/resume/cancel fuzzing tasks |
+| `caido_create_automate_session` | Create a fuzzing session seeded from a request ID or raw HTTP |
+| `caido_rename_automate_session` | Rename a fuzzing session |
+| `caido_delete_automate_session` | Delete a fuzzing session and its results |
 | `caido_list_findings` | List security findings |
 | `caido_create_finding` | Create finding linked to a request |
 | `caido_delete_findings` | Delete findings by IDs or reporter name |
 | `caido_export_findings` | Export findings for reporting |
+| `caido_get_finding` | Get a single finding with its linked request |
+| `caido_list_finding_reporters` | List all finding reporter names |
 | `caido_get_sitemap` | Browse sitemap hierarchy |
+| `caido_get_sitemap_entry` | Get a single sitemap entry |
+| `caido_clear_sitemap` | Clear the entire sitemap tree |
+| `caido_delete_sitemap_entries` | Delete specific sitemap entries by ID |
 | `caido_list_scopes` | List target scopes |
 | `caido_create_scope` | Create new scope with allow/deny lists |
 | `caido_rename_scope` | Rename a scope |
@@ -183,17 +196,32 @@ This opens your browser for OAuth authentication and saves the token to `~/.caid
 | `caido_list_workflows` | List automation workflows |
 | `caido_run_workflow` | Execute an active or convert workflow |
 | `caido_toggle_workflow` | Enable or disable a workflow |
+| `caido_get_workflow` | Get a workflow including its node-graph definition |
+| `caido_create_workflow` | Create a workflow from a node-graph definition (JSON) |
+| `caido_rename_workflow` | Rename a workflow |
+| `caido_delete_workflow` | Delete a workflow |
+| `caido_set_workflow_scope` | Globalize or localize a workflow |
+| `caido_list_workflow_node_definitions` | List available workflow node definitions |
 | `caido_list_tamper_rules` | List Match & Replace rule collections |
 | `caido_create_tamper_rule` | Create a tamper rule in a collection |
 | `caido_update_tamper_rule` | Update an existing tamper rule |
 | `caido_toggle_tamper_rule` | Enable or disable a tamper rule |
 | `caido_delete_tamper_rule` | Delete a tamper rule |
+| `caido_get_tamper_rule` | Get a tamper rule by ID |
+| `caido_create_tamper_collection` | Create a tamper rule collection |
+| `caido_delete_tamper_collection` | Delete a tamper rule collection and its rules |
 | `caido_get_instance` | Get Caido version and platform info |
+| `caido_whoami` | Get the currently authenticated user |
 | `caido_intercept_status` | Get intercept status (PAUSED/RUNNING) |
 | `caido_intercept_control` | Pause or resume intercept |
 | `caido_list_intercept_entries` | List queued intercept entries with HTTPQL filtering |
 | `caido_forward_intercept` | Forward intercepted request, optionally with modifications |
 | `caido_drop_intercept` | Drop intercepted request |
+| `caido_get_intercept_entry` | Get a single intercept entry with request/response |
+| `caido_get_intercept_options` | Get intercept proxy configuration |
+| `caido_set_intercept_options` | Configure request/response/WebSocket interception and scope |
+| `caido_delete_intercept_entry` | Delete a single intercept queue entry |
+| `caido_delete_intercept_entries` | Delete intercept entries matching an HTTPQL filter |
 | `caido_list_environments` | List environments and their variables |
 | `caido_select_environment` | Switch active environment |
 | `caido_create_environment` | Create a new environment |
@@ -202,9 +230,14 @@ This opens your browser for OAuth authentication and saves the token to `~/.caid
 | `caido_create_filter` | Save an HTTPQL query as a named filter preset |
 | `caido_delete_filter` | Delete a filter preset |
 | `caido_list_hosted_files` | List hosted payload files |
+| `caido_rename_hosted_file` | Rename a hosted file |
+| `caido_delete_hosted_file` | Delete a hosted file |
 | `caido_list_tasks` | List running background tasks |
 | `caido_cancel_task` | Cancel a running task by ID |
 | `caido_list_plugins` | List installed plugin packages |
+| `caido_install_plugin` | Install a plugin from a url or store manifest ID |
+| `caido_delete_plugin` | Uninstall an upstream plugin |
+| `caido_toggle_plugin` | Enable or disable a plugin |
 
 ### MCP Resources (4)
 

--- a/internal/tools/clear_sitemap.go
+++ b/internal/tools/clear_sitemap.go
@@ -1,0 +1,43 @@
+package tools
+
+import (
+	"context"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ClearSitemapInput struct{}
+
+type ClearSitemapOutput struct {
+	Success      bool `json:"success"`
+	DeletedCount int  `json:"deletedCount"`
+}
+
+func clearSitemapHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, ClearSitemapInput) (*mcp.CallToolResult, ClearSitemapOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input ClearSitemapInput,
+	) (*mcp.CallToolResult, ClearSitemapOutput, error) {
+		resp, err := client.Sitemap.Clear(ctx)
+		if err != nil {
+			return nil, ClearSitemapOutput{}, err
+		}
+
+		return nil, ClearSitemapOutput{
+			Success:      true,
+			DeletedCount: len(resp.ClearSitemapEntries.DeletedIds),
+		}, nil
+	}
+}
+
+func RegisterClearSitemapTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_clear_sitemap",
+		Description: `Clear the entire sitemap tree. Destructive: removes all sitemap entries.`,
+		InputSchema: map[string]any{"type": "object"},
+	}, clearSitemapHandler(client))
+}

--- a/internal/tools/create_automate_session.go
+++ b/internal/tools/create_automate_session.go
@@ -1,0 +1,127 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/c0tton-fluff/caido-mcp-server/internal/httputil"
+	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// CreateAutomateSessionInput is the input for the create_automate_session tool
+type CreateAutomateSessionInput struct {
+	RequestID string `json:"requestId,omitempty" jsonschema:"Existing request ID to seed the fuzzing session with"`
+	Raw       string `json:"raw,omitempty" jsonschema:"Raw HTTP request to seed the session (alternative to requestId)"`
+	Host      string `json:"host,omitempty" jsonschema:"Target host (required when using raw, overrides Host header)"`
+	Port      int    `json:"port,omitempty" jsonschema:"Target port (default based on TLS)"`
+	TLS       *bool  `json:"tls,omitempty" jsonschema:"Use HTTPS (default true, only for raw)"`
+}
+
+// CreateAutomateSessionOutput is the output of the create_automate_session tool
+type CreateAutomateSessionOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func createAutomateSessionHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, CreateAutomateSessionInput) (*mcp.CallToolResult, CreateAutomateSessionOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input CreateAutomateSessionInput,
+	) (*mcp.CallToolResult, CreateAutomateSessionOutput, error) {
+		if input.RequestID == "" && input.Raw == "" {
+			return nil, CreateAutomateSessionOutput{}, fmt.Errorf(
+				"either requestId or raw is required to seed the session",
+			)
+		}
+
+		source := &gen.RequestSourceInput{}
+		switch {
+		case input.RequestID != "":
+			source.Id = &input.RequestID
+		default:
+			if len(input.Raw) > 1048576 {
+				return nil, CreateAutomateSessionOutput{}, fmt.Errorf(
+					"raw request exceeds max length of 1MB",
+				)
+			}
+			raw := httputil.NormalizeCRLF(input.Raw)
+
+			host := input.Host
+			if host == "" {
+				host = httputil.ParseHostHeader(input.Raw)
+			}
+			if host == "" {
+				return nil, CreateAutomateSessionOutput{}, fmt.Errorf(
+					"host is required when using raw (provide host or a Host header)",
+				)
+			}
+			if h, p, err := net.SplitHostPort(host); err == nil {
+				host = h
+				if input.Port == 0 {
+					if port, pErr := strconv.Atoi(p); pErr == nil {
+						input.Port = port
+					}
+				}
+			}
+
+			useTLS := true
+			if input.TLS != nil {
+				useTLS = *input.TLS
+			}
+			port := input.Port
+			if port == 0 {
+				if useTLS {
+					port = 443
+				} else {
+					port = 80
+				}
+			}
+
+			source.Raw = &gen.RequestRawInput{
+				ConnectionInfo: gen.ConnectionInfoInput{
+					Host:  host,
+					Port:  port,
+					IsTLS: useTLS,
+				},
+				Raw: base64.StdEncoding.EncodeToString([]byte(raw)),
+			}
+		}
+
+		resp, err := client.Automate.CreateSession(ctx, &gen.CreateAutomateSessionInput{
+			RequestSource: source,
+		})
+		if err != nil {
+			return nil, CreateAutomateSessionOutput{}, fmt.Errorf("create automate session: %w", err)
+		}
+
+		session := resp.CreateAutomateSession.Session
+		if session == nil {
+			return nil, CreateAutomateSessionOutput{}, fmt.Errorf("create automate session returned nil")
+		}
+
+		return nil, CreateAutomateSessionOutput{
+			ID:   session.Id,
+			Name: session.Name,
+		}, nil
+	}
+}
+
+func RegisterCreateAutomateSessionTool(
+	server *mcp.Server, client *caido.Client,
+) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_create_automate_session",
+		Description: `Create an Automate (fuzzing) session seeded from an existing ` +
+			`request (requestId) or a raw HTTP request (raw + host). Returns the ` +
+			`new session id. Configure payload placeholders in the Caido UI, then ` +
+			`start fuzzing with caido_automate_task_control.`,
+	}, createAutomateSessionHandler(client))
+}

--- a/internal/tools/create_tamper_collection.go
+++ b/internal/tools/create_tamper_collection.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type CreateTamperCollectionInput struct {
+	Name string `json:"name" jsonschema:"required,Collection name"`
+}
+
+type CreateTamperCollectionOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func createTamperCollectionHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, CreateTamperCollectionInput) (*mcp.CallToolResult, CreateTamperCollectionOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input CreateTamperCollectionInput,
+	) (*mcp.CallToolResult, CreateTamperCollectionOutput, error) {
+		resp, err := client.Tamper.CreateCollection(ctx, &gen.CreateTamperRuleCollectionInput{
+			Name: input.Name,
+		})
+		if err != nil {
+			return nil, CreateTamperCollectionOutput{}, err
+		}
+
+		coll := resp.CreateTamperRuleCollection.Collection
+		if coll == nil {
+			return nil, CreateTamperCollectionOutput{}, fmt.Errorf("create tamper collection returned nil")
+		}
+
+		return nil, CreateTamperCollectionOutput{
+			ID:   coll.Id,
+			Name: coll.Name,
+		}, nil
+	}
+}
+
+func RegisterCreateTamperCollectionTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_create_tamper_collection",
+		Description: `Create a Match & Replace (tamper) rule collection. Use the ` +
+			`returned id as collection_id for caido_create_tamper_rule.`,
+	}, createTamperCollectionHandler(client))
+}

--- a/internal/tools/create_workflow.go
+++ b/internal/tools/create_workflow.go
@@ -1,0 +1,73 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type CreateWorkflowInput struct {
+	Definition string `json:"definition" jsonschema:"required,Workflow node-graph definition as a JSON string (see caido_get_workflow output for the schema)"`
+	Global     bool   `json:"global,omitempty" jsonschema:"Create as a global workflow shared across projects (default false)"`
+}
+
+type CreateWorkflowOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func createWorkflowHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, CreateWorkflowInput) (*mcp.CallToolResult, CreateWorkflowOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input CreateWorkflowInput,
+	) (*mcp.CallToolResult, CreateWorkflowOutput, error) {
+		if input.Definition == "" {
+			return nil, CreateWorkflowOutput{}, fmt.Errorf("definition is required")
+		}
+		if !json.Valid([]byte(input.Definition)) {
+			return nil, CreateWorkflowOutput{}, fmt.Errorf("definition is not valid JSON")
+		}
+
+		resp, err := client.Workflows.Create(ctx, &gen.CreateWorkflowInput{
+			Definition: json.RawMessage(input.Definition),
+			Global:     input.Global,
+		})
+		if err != nil {
+			return nil, CreateWorkflowOutput{}, err
+		}
+
+		payload := resp.CreateWorkflow
+		if payload.Error != nil {
+			errType := "unknown"
+			if tn := (*payload.Error).GetTypename(); tn != nil {
+				errType = *tn
+			}
+			return nil, CreateWorkflowOutput{}, fmt.Errorf("create workflow failed: %s", errType)
+		}
+		if payload.Workflow == nil {
+			return nil, CreateWorkflowOutput{}, fmt.Errorf("create workflow returned no workflow")
+		}
+
+		return nil, CreateWorkflowOutput{
+			ID:   payload.Workflow.Id,
+			Name: payload.Workflow.Name,
+		}, nil
+	}
+}
+
+func RegisterCreateWorkflowTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_create_workflow",
+		Description: `Create a workflow from a node-graph definition (JSON). ` +
+			`Fetch an existing workflow with caido_get_workflow to learn the ` +
+			`definition schema, and list available nodes with ` +
+			`caido_list_workflow_node_definitions.`,
+	}, createWorkflowHandler(client))
+}

--- a/internal/tools/delete_automate_session.go
+++ b/internal/tools/delete_automate_session.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DeleteAutomateSessionInput struct {
+	ID string `json:"id" jsonschema:"required,Automate session ID to delete"`
+}
+
+type DeleteAutomateSessionOutput struct {
+	Success   bool   `json:"success"`
+	DeletedID string `json:"deletedId,omitempty"`
+}
+
+func deleteAutomateSessionHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, DeleteAutomateSessionInput) (*mcp.CallToolResult, DeleteAutomateSessionOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input DeleteAutomateSessionInput,
+	) (*mcp.CallToolResult, DeleteAutomateSessionOutput, error) {
+		resp, err := client.Automate.DeleteSession(ctx, input.ID)
+		if err != nil {
+			return nil, DeleteAutomateSessionOutput{}, fmt.Errorf("delete automate session: %w", err)
+		}
+
+		out := DeleteAutomateSessionOutput{Success: true}
+		if id := resp.DeleteAutomateSession.DeletedId; id != nil {
+			out.DeletedID = *id
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterDeleteAutomateSessionTool(
+	server *mcp.Server, client *caido.Client,
+) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_delete_automate_session",
+		Description: `Delete an Automate (fuzzing) session and its results.`,
+	}, deleteAutomateSessionHandler(client))
+}

--- a/internal/tools/delete_hosted_file.go
+++ b/internal/tools/delete_hosted_file.go
@@ -1,0 +1,45 @@
+package tools
+
+import (
+	"context"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DeleteHostedFileInput struct {
+	ID string `json:"id" jsonschema:"required,Hosted file ID to delete"`
+}
+
+type DeleteHostedFileOutput struct {
+	Success   bool   `json:"success"`
+	DeletedID string `json:"deletedId,omitempty"`
+}
+
+func deleteHostedFileHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, DeleteHostedFileInput) (*mcp.CallToolResult, DeleteHostedFileOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input DeleteHostedFileInput,
+	) (*mcp.CallToolResult, DeleteHostedFileOutput, error) {
+		resp, err := client.HostedFiles.Delete(ctx, input.ID)
+		if err != nil {
+			return nil, DeleteHostedFileOutput{}, err
+		}
+
+		out := DeleteHostedFileOutput{Success: true}
+		if id := resp.DeleteHostedFile.DeletedId; id != nil {
+			out.DeletedID = *id
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterDeleteHostedFileTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_delete_hosted_file",
+		Description: `Delete a hosted file by ID.`,
+	}, deleteHostedFileHandler(client))
+}

--- a/internal/tools/delete_intercept_entries.go
+++ b/internal/tools/delete_intercept_entries.go
@@ -1,0 +1,52 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DeleteInterceptEntriesInput struct {
+	Filter  string  `json:"filter,omitempty" jsonschema:"HTTPQL filter selecting entries to delete (omit to clear all)"`
+	ScopeID *string `json:"scopeId,omitempty" jsonschema:"Restrict deletion to this scope ID"`
+}
+
+type DeleteInterceptEntriesOutput struct {
+	Success bool `json:"success"`
+}
+
+func deleteInterceptEntriesHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, DeleteInterceptEntriesInput) (*mcp.CallToolResult, DeleteInterceptEntriesOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input DeleteInterceptEntriesInput,
+	) (*mcp.CallToolResult, DeleteInterceptEntriesOutput, error) {
+		if len(input.Filter) > 10000 {
+			return nil, DeleteInterceptEntriesOutput{}, fmt.Errorf("filter exceeds max length of 10000")
+		}
+
+		var filter *string
+		if input.Filter != "" {
+			filter = &input.Filter
+		}
+
+		_, err := client.Intercept.DeleteEntries(ctx, filter, input.ScopeID)
+		if err != nil {
+			return nil, DeleteInterceptEntriesOutput{}, err
+		}
+
+		return nil, DeleteInterceptEntriesOutput{Success: true}, nil
+	}
+}
+
+func RegisterDeleteInterceptEntriesTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_delete_intercept_entries",
+		Description: `Delete intercept queue entries matching an HTTPQL filter ` +
+			`(omit filter to clear the entire queue). Runs as a background task.`,
+	}, deleteInterceptEntriesHandler(client))
+}

--- a/internal/tools/delete_intercept_entry.go
+++ b/internal/tools/delete_intercept_entry.go
@@ -1,0 +1,50 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DeleteInterceptEntryInput struct {
+	ID string `json:"id" jsonschema:"required,Intercept entry ID to delete"`
+}
+
+type DeleteInterceptEntryOutput struct {
+	Success   bool   `json:"success"`
+	DeletedID string `json:"deletedId,omitempty"`
+}
+
+func deleteInterceptEntryHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, DeleteInterceptEntryInput) (*mcp.CallToolResult, DeleteInterceptEntryOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input DeleteInterceptEntryInput,
+	) (*mcp.CallToolResult, DeleteInterceptEntryOutput, error) {
+		if input.ID == "" {
+			return nil, DeleteInterceptEntryOutput{}, fmt.Errorf("id is required")
+		}
+
+		resp, err := client.Intercept.DeleteEntry(ctx, input.ID)
+		if err != nil {
+			return nil, DeleteInterceptEntryOutput{}, err
+		}
+
+		out := DeleteInterceptEntryOutput{Success: true}
+		if id := resp.DeleteInterceptEntry.DeletedId; id != nil {
+			out.DeletedID = *id
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterDeleteInterceptEntryTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_delete_intercept_entry",
+		Description: `Delete a single intercept queue entry by ID.`,
+	}, deleteInterceptEntryHandler(client))
+}

--- a/internal/tools/delete_plugin.go
+++ b/internal/tools/delete_plugin.go
@@ -1,0 +1,45 @@
+package tools
+
+import (
+	"context"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DeletePluginInput struct {
+	ID string `json:"id" jsonschema:"required,Upstream plugin ID to delete"`
+}
+
+type DeletePluginOutput struct {
+	Success   bool   `json:"success"`
+	DeletedID string `json:"deletedId,omitempty"`
+}
+
+func deletePluginHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, DeletePluginInput) (*mcp.CallToolResult, DeletePluginOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input DeletePluginInput,
+	) (*mcp.CallToolResult, DeletePluginOutput, error) {
+		resp, err := client.Plugins.DeleteUpstreamPlugin(ctx, input.ID)
+		if err != nil {
+			return nil, DeletePluginOutput{}, err
+		}
+
+		out := DeletePluginOutput{Success: true}
+		if id := resp.DeleteUpstreamPlugin.DeletedId; id != nil {
+			out.DeletedID = *id
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterDeletePluginTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_delete_plugin",
+		Description: `Delete (uninstall) an upstream plugin by ID.`,
+	}, deletePluginHandler(client))
+}

--- a/internal/tools/delete_sitemap_entries.go
+++ b/internal/tools/delete_sitemap_entries.go
@@ -1,0 +1,50 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DeleteSitemapEntriesInput struct {
+	IDs []string `json:"ids" jsonschema:"required,Sitemap entry IDs to delete"`
+}
+
+type DeleteSitemapEntriesOutput struct {
+	Success      bool `json:"success"`
+	DeletedCount int  `json:"deletedCount"`
+}
+
+func deleteSitemapEntriesHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, DeleteSitemapEntriesInput) (*mcp.CallToolResult, DeleteSitemapEntriesOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input DeleteSitemapEntriesInput,
+	) (*mcp.CallToolResult, DeleteSitemapEntriesOutput, error) {
+		if len(input.IDs) == 0 {
+			return nil, DeleteSitemapEntriesOutput{}, fmt.Errorf("ids is required")
+		}
+
+		resp, err := client.Sitemap.Delete(ctx, input.IDs)
+		if err != nil {
+			return nil, DeleteSitemapEntriesOutput{}, err
+		}
+
+		return nil, DeleteSitemapEntriesOutput{
+			Success:      true,
+			DeletedCount: len(resp.DeleteSitemapEntries.DeletedIds),
+		}, nil
+	}
+}
+
+func RegisterDeleteSitemapEntriesTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_delete_sitemap_entries",
+		Description: `Delete specific sitemap entries by ID. Deleting a node also ` +
+			`removes its descendants.`,
+	}, deleteSitemapEntriesHandler(client))
+}

--- a/internal/tools/delete_tamper_collection.go
+++ b/internal/tools/delete_tamper_collection.go
@@ -1,0 +1,45 @@
+package tools
+
+import (
+	"context"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DeleteTamperCollectionInput struct {
+	ID string `json:"id" jsonschema:"required,Tamper rule collection ID to delete"`
+}
+
+type DeleteTamperCollectionOutput struct {
+	Success   bool   `json:"success"`
+	DeletedID string `json:"deletedId,omitempty"`
+}
+
+func deleteTamperCollectionHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, DeleteTamperCollectionInput) (*mcp.CallToolResult, DeleteTamperCollectionOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input DeleteTamperCollectionInput,
+	) (*mcp.CallToolResult, DeleteTamperCollectionOutput, error) {
+		resp, err := client.Tamper.DeleteCollection(ctx, input.ID)
+		if err != nil {
+			return nil, DeleteTamperCollectionOutput{}, err
+		}
+
+		out := DeleteTamperCollectionOutput{Success: true}
+		if id := resp.DeleteTamperRuleCollection.DeletedId; id != nil {
+			out.DeletedID = *id
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterDeleteTamperCollectionTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_delete_tamper_collection",
+		Description: `Delete a Match & Replace (tamper) rule collection and its rules.`,
+	}, deleteTamperCollectionHandler(client))
+}

--- a/internal/tools/delete_workflow.go
+++ b/internal/tools/delete_workflow.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type DeleteWorkflowInput struct {
+	ID string `json:"id" jsonschema:"required,Workflow ID to delete"`
+}
+
+type DeleteWorkflowOutput struct {
+	Success   bool   `json:"success"`
+	DeletedID string `json:"deletedId,omitempty"`
+}
+
+func deleteWorkflowHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, DeleteWorkflowInput) (*mcp.CallToolResult, DeleteWorkflowOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input DeleteWorkflowInput,
+	) (*mcp.CallToolResult, DeleteWorkflowOutput, error) {
+		resp, err := client.Workflows.Delete(ctx, input.ID)
+		if err != nil {
+			return nil, DeleteWorkflowOutput{}, err
+		}
+
+		payload := resp.DeleteWorkflow
+		if payload.Error != nil {
+			errType := "unknown"
+			if tn := (*payload.Error).GetTypename(); tn != nil {
+				errType = *tn
+			}
+			return nil, DeleteWorkflowOutput{}, fmt.Errorf("delete workflow failed: %s", errType)
+		}
+
+		out := DeleteWorkflowOutput{Success: true}
+		if payload.DeletedId != nil {
+			out.DeletedID = *payload.DeletedId
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterDeleteWorkflowTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_delete_workflow",
+		Description: `Delete a workflow.`,
+	}, deleteWorkflowHandler(client))
+}

--- a/internal/tools/get_finding.go
+++ b/internal/tools/get_finding.go
@@ -1,0 +1,74 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/c0tton-fluff/caido-mcp-server/internal/httputil"
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetFindingInput struct {
+	ID string `json:"id" jsonschema:"required,Finding ID"`
+}
+
+type GetFindingOutput struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	Description *string `json:"description,omitempty"`
+	Reporter    string  `json:"reporter"`
+	Host        string  `json:"host"`
+	Path        string  `json:"path"`
+	Hidden      bool    `json:"hidden"`
+	DedupeKey   *string `json:"dedupeKey,omitempty"`
+	CreatedAt   string  `json:"createdAt"`
+	RequestID   string  `json:"requestId"`
+	RequestURL  string  `json:"requestUrl"`
+}
+
+func getFindingHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetFindingInput) (*mcp.CallToolResult, GetFindingOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetFindingInput,
+	) (*mcp.CallToolResult, GetFindingOutput, error) {
+		resp, err := client.Findings.Get(ctx, input.ID)
+		if err != nil {
+			return nil, GetFindingOutput{}, err
+		}
+
+		f := resp.Finding
+		if f == nil {
+			return nil, GetFindingOutput{}, fmt.Errorf("finding not found")
+		}
+
+		return nil, GetFindingOutput{
+			ID:          f.Id,
+			Title:       f.Title,
+			Description: f.Description,
+			Reporter:    f.Reporter,
+			Host:        f.Host,
+			Path:        f.Path,
+			Hidden:      f.Hidden,
+			DedupeKey:   f.DedupeKey,
+			CreatedAt:   time.UnixMilli(f.CreatedAt).Format(time.RFC3339),
+			RequestID:   f.Request.Id,
+			RequestURL: httputil.BuildURL(
+				f.Request.IsTls, f.Request.Host, f.Request.Port,
+				f.Request.Path, f.Request.Query,
+			),
+		}, nil
+	}
+}
+
+func RegisterGetFindingTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_get_finding",
+		Description: `Get a single security finding by ID: title, description, ` +
+			`reporter, and the request it is attached to.`,
+	}, getFindingHandler(client))
+}

--- a/internal/tools/get_intercept_entry.go
+++ b/internal/tools/get_intercept_entry.go
@@ -1,0 +1,88 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/c0tton-fluff/caido-mcp-server/internal/httputil"
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetInterceptEntryInput struct {
+	ID         string `json:"id" jsonschema:"required,Intercept entry ID"`
+	BodyLimit  int    `json:"bodyLimit,omitempty" jsonschema:"Response body byte limit (default adaptive)"`
+	BodyOffset int    `json:"bodyOffset,omitempty" jsonschema:"Response body byte offset (default 0)"`
+}
+
+type GetInterceptEntryOutput struct {
+	ID         string                  `json:"id"`
+	RequestID  string                  `json:"requestId"`
+	Method     string                  `json:"method"`
+	URL        string                  `json:"url"`
+	CreatedAt  string                  `json:"createdAt"`
+	StatusCode int                     `json:"statusCode,omitempty"`
+	Request    *httputil.ParsedMessage `json:"request,omitempty"`
+	Response   *httputil.ParsedMessage `json:"response,omitempty"`
+}
+
+func getInterceptEntryHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetInterceptEntryInput) (*mcp.CallToolResult, GetInterceptEntryOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetInterceptEntryInput,
+	) (*mcp.CallToolResult, GetInterceptEntryOutput, error) {
+		if input.ID == "" {
+			return nil, GetInterceptEntryOutput{}, fmt.Errorf("id is required")
+		}
+
+		resp, err := client.Intercept.GetEntry(ctx, input.ID)
+		if err != nil {
+			return nil, GetInterceptEntryOutput{}, err
+		}
+
+		entry := resp.InterceptEntry
+		if entry == nil {
+			return nil, GetInterceptEntryOutput{}, fmt.Errorf("intercept entry not found")
+		}
+
+		r := entry.Request
+		out := GetInterceptEntryOutput{
+			ID:        entry.Id,
+			RequestID: r.Id,
+			Method:    r.Method,
+			URL:       httputil.BuildURL(r.IsTls, r.Host, r.Port, r.Path, r.Query),
+			CreatedAt: time.UnixMilli(r.CreatedAt).Format(time.RFC3339),
+			Request:   httputil.ParseBase64(r.Raw, true, false, 0, 0),
+		}
+
+		if r.Response != nil {
+			out.StatusCode = r.Response.StatusCode
+			bodyLimit := input.BodyLimit
+			if bodyLimit == 0 {
+				headersOnly := httputil.ParseBase64(r.Response.Raw, true, false, 0, 0)
+				if headersOnly != nil && headersOnly.Fingerprint != nil {
+					bodyLimit = httputil.AdaptiveBodyLimit(*headersOnly.Fingerprint, 0)
+				} else {
+					bodyLimit = httputil.DefaultBodyLimit
+				}
+			}
+			out.Response = httputil.ParseBase64(
+				r.Response.Raw, true, true, input.BodyOffset, bodyLimit,
+			)
+		}
+
+		return nil, out, nil
+	}
+}
+
+func RegisterGetInterceptEntryTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_get_intercept_entry",
+		Description: `Get a single intercept entry by ID with its full request ` +
+			`(and response, if already received). Use after caido_list_intercept_entries.`,
+	}, getInterceptEntryHandler(client))
+}

--- a/internal/tools/get_intercept_options.go
+++ b/internal/tools/get_intercept_options.go
@@ -1,0 +1,50 @@
+package tools
+
+import (
+	"context"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetInterceptOptionsInput struct{}
+
+type GetInterceptOptionsOutput struct {
+	RequestEnabled  bool   `json:"requestEnabled"`
+	ResponseEnabled bool   `json:"responseEnabled"`
+	ScopeID         string `json:"scopeId,omitempty"`
+}
+
+func getInterceptOptionsHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetInterceptOptionsInput) (*mcp.CallToolResult, GetInterceptOptionsOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetInterceptOptionsInput,
+	) (*mcp.CallToolResult, GetInterceptOptionsOutput, error) {
+		resp, err := client.Intercept.GetOptions(ctx)
+		if err != nil {
+			return nil, GetInterceptOptionsOutput{}, err
+		}
+
+		opts := resp.InterceptOptions
+		out := GetInterceptOptionsOutput{
+			RequestEnabled:  opts.Request.Enabled,
+			ResponseEnabled: opts.Response.Enabled,
+		}
+		if opts.Scope != nil {
+			out.ScopeID = opts.Scope.ScopeId
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterGetInterceptOptionsTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_get_intercept_options",
+		Description: `Get intercept proxy configuration: whether request/response ` +
+			`interception is enabled and the active scope, if any.`,
+		InputSchema: map[string]any{"type": "object"},
+	}, getInterceptOptionsHandler(client))
+}

--- a/internal/tools/get_replay_session.go
+++ b/internal/tools/get_replay_session.go
@@ -1,0 +1,62 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetReplaySessionInput struct {
+	ID string `json:"id" jsonschema:"required,Replay session ID"`
+}
+
+type GetReplaySessionOutput struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	CollectionID   string `json:"collectionId"`
+	CollectionName string `json:"collectionName"`
+	ActiveEntryID  string `json:"activeEntryId,omitempty"`
+	EntryCount     int    `json:"entryCount"`
+}
+
+func getReplaySessionHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetReplaySessionInput) (*mcp.CallToolResult, GetReplaySessionOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetReplaySessionInput,
+	) (*mcp.CallToolResult, GetReplaySessionOutput, error) {
+		resp, err := client.Replay.GetSession(ctx, input.ID)
+		if err != nil {
+			return nil, GetReplaySessionOutput{}, err
+		}
+
+		s := resp.ReplaySession
+		if s == nil {
+			return nil, GetReplaySessionOutput{}, fmt.Errorf("replay session not found")
+		}
+
+		out := GetReplaySessionOutput{
+			ID:             s.Id,
+			Name:           s.Name,
+			CollectionID:   s.Collection.Id,
+			CollectionName: s.Collection.Name,
+			EntryCount:     len(s.Entries.Edges),
+		}
+		if s.ActiveEntry != nil {
+			out.ActiveEntryID = s.ActiveEntry.Id
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterGetReplaySessionTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_get_replay_session",
+		Description: `Get a replay session by ID: name, collection, active entry, and ` +
+			`how many entries it contains.`,
+	}, getReplaySessionHandler(client))
+}

--- a/internal/tools/get_request_metadata.go
+++ b/internal/tools/get_request_metadata.go
@@ -1,0 +1,72 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/c0tton-fluff/caido-mcp-server/internal/httputil"
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetRequestMetadataInput struct {
+	ID string `json:"id" jsonschema:"required,Request ID"`
+}
+
+type GetRequestMetadataOutput struct {
+	ID            string `json:"id"`
+	Method        string `json:"method"`
+	URL           string `json:"url"`
+	Source        string `json:"source"`
+	Alteration    string `json:"alteration"`
+	Length        int    `json:"length"`
+	CreatedAt     string `json:"createdAt"`
+	StatusCode    int    `json:"statusCode,omitempty"`
+	RoundtripMs   int    `json:"roundtripMs,omitempty"`
+	ResponseBytes int    `json:"responseBytes,omitempty"`
+}
+
+func getRequestMetadataHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetRequestMetadataInput) (*mcp.CallToolResult, GetRequestMetadataOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetRequestMetadataInput,
+	) (*mcp.CallToolResult, GetRequestMetadataOutput, error) {
+		resp, err := client.Requests.GetMetadata(ctx, input.ID)
+		if err != nil {
+			return nil, GetRequestMetadataOutput{}, err
+		}
+
+		r := resp.Request
+		if r == nil {
+			return nil, GetRequestMetadataOutput{}, fmt.Errorf("request not found")
+		}
+
+		out := GetRequestMetadataOutput{
+			ID:         r.Id,
+			Method:     r.Method,
+			URL:        httputil.BuildURL(r.IsTls, r.Host, r.Port, r.Path, r.Query),
+			Source:     string(r.Source),
+			Alteration: string(r.Alteration),
+			Length:     r.Length,
+			CreatedAt:  time.UnixMilli(r.CreatedAt).Format(time.RFC3339),
+		}
+		if r.Response != nil {
+			out.StatusCode = r.Response.StatusCode
+			out.RoundtripMs = r.Response.RoundtripTime
+			out.ResponseBytes = r.Response.Length
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterGetRequestMetadataTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_get_request_metadata",
+		Description: `Get request metadata (method, url, status, timing, sizes) WITHOUT ` +
+			`raw bodies. Lighter than caido_get_request when you only need summary info.`,
+	}, getRequestMetadataHandler(client))
+}

--- a/internal/tools/get_sitemap_entry.go
+++ b/internal/tools/get_sitemap_entry.go
@@ -1,0 +1,57 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetSitemapEntryInput struct {
+	ID string `json:"id" jsonschema:"required,Sitemap entry ID"`
+}
+
+type GetSitemapEntryOutput struct {
+	ID             string  `json:"id"`
+	Label          string  `json:"label"`
+	Kind           string  `json:"kind"`
+	ParentID       *string `json:"parentId,omitempty"`
+	HasDescendants bool    `json:"hasDescendants"`
+}
+
+func getSitemapEntryHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetSitemapEntryInput) (*mcp.CallToolResult, GetSitemapEntryOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetSitemapEntryInput,
+	) (*mcp.CallToolResult, GetSitemapEntryOutput, error) {
+		resp, err := client.Sitemap.GetEntry(ctx, input.ID)
+		if err != nil {
+			return nil, GetSitemapEntryOutput{}, err
+		}
+
+		e := resp.SitemapEntry
+		if e == nil {
+			return nil, GetSitemapEntryOutput{}, fmt.Errorf("sitemap entry not found")
+		}
+
+		return nil, GetSitemapEntryOutput{
+			ID:             e.Id,
+			Label:          e.Label,
+			Kind:           string(e.Kind),
+			ParentID:       e.ParentId,
+			HasDescendants: e.HasDescendants,
+		}, nil
+	}
+}
+
+func RegisterGetSitemapEntryTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_get_sitemap_entry",
+		Description: `Get a single sitemap entry by ID (label, kind, parent, whether ` +
+			`it has children). Use caido_get_sitemap to browse the tree.`,
+	}, getSitemapEntryHandler(client))
+}

--- a/internal/tools/get_tamper_rule.go
+++ b/internal/tools/get_tamper_rule.go
@@ -1,0 +1,64 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetTamperRuleInput struct {
+	ID string `json:"id" jsonschema:"required,Tamper rule ID"`
+}
+
+type GetTamperRuleOutput struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Enabled        bool     `json:"enabled"`
+	Sources        []string `json:"sources"`
+	CollectionID   string   `json:"collectionId"`
+	CollectionName string   `json:"collectionName"`
+}
+
+func getTamperRuleHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetTamperRuleInput) (*mcp.CallToolResult, GetTamperRuleOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetTamperRuleInput,
+	) (*mcp.CallToolResult, GetTamperRuleOutput, error) {
+		resp, err := client.Tamper.GetRule(ctx, input.ID)
+		if err != nil {
+			return nil, GetTamperRuleOutput{}, err
+		}
+
+		rule := resp.TamperRule
+		if rule == nil {
+			return nil, GetTamperRuleOutput{}, fmt.Errorf("tamper rule not found")
+		}
+
+		sources := make([]string, 0, len(rule.Sources))
+		for _, s := range rule.Sources {
+			sources = append(sources, string(s))
+		}
+
+		return nil, GetTamperRuleOutput{
+			ID:             rule.Id,
+			Name:           rule.Name,
+			Enabled:        rule.Enable != nil,
+			Sources:        sources,
+			CollectionID:   rule.Collection.Id,
+			CollectionName: rule.Collection.Name,
+		}, nil
+	}
+}
+
+func RegisterGetTamperRuleTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_get_tamper_rule",
+		Description: `Get a Match & Replace (tamper) rule by ID: name, whether it's ` +
+			`enabled, traffic sources, and its collection.`,
+	}, getTamperRuleHandler(client))
+}

--- a/internal/tools/get_workflow.go
+++ b/internal/tools/get_workflow.go
@@ -1,0 +1,66 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type GetWorkflowInput struct {
+	ID string `json:"id" jsonschema:"required,Workflow ID"`
+}
+
+type GetWorkflowOutput struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	Enabled    bool   `json:"enabled"`
+	Global     bool   `json:"global"`
+	ReadOnly   bool   `json:"readOnly"`
+	Definition string `json:"definition"`
+	CreatedAt  string `json:"createdAt"`
+	UpdatedAt  string `json:"updatedAt"`
+}
+
+func getWorkflowHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, GetWorkflowInput) (*mcp.CallToolResult, GetWorkflowOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input GetWorkflowInput,
+	) (*mcp.CallToolResult, GetWorkflowOutput, error) {
+		resp, err := client.Workflows.Get(ctx, input.ID)
+		if err != nil {
+			return nil, GetWorkflowOutput{}, err
+		}
+
+		wf := resp.Workflow
+		if wf == nil {
+			return nil, GetWorkflowOutput{}, fmt.Errorf("workflow not found")
+		}
+
+		return nil, GetWorkflowOutput{
+			ID:         wf.Id,
+			Name:       wf.Name,
+			Kind:       string(wf.Kind),
+			Enabled:    wf.Enabled,
+			Global:     wf.Global,
+			ReadOnly:   wf.ReadOnly,
+			Definition: string(wf.Definition),
+			CreatedAt:  wf.CreatedAt,
+			UpdatedAt:  wf.UpdatedAt,
+		}, nil
+	}
+}
+
+func RegisterGetWorkflowTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_get_workflow",
+		Description: `Get a workflow by ID including its full node-graph ` +
+			`definition (JSON). Use this to inspect or clone an existing ` +
+			`workflow before editing.`,
+	}, getWorkflowHandler(client))
+}

--- a/internal/tools/install_plugin.go
+++ b/internal/tools/install_plugin.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type InstallPluginInput struct {
+	URL        string `json:"url,omitempty" jsonschema:"URL of the plugin package to install"`
+	ManifestID string `json:"manifestId,omitempty" jsonschema:"Store manifest ID of the plugin package to install"`
+	Force      *bool  `json:"force,omitempty" jsonschema:"Force install even if already present"`
+}
+
+type InstallPluginOutput struct {
+	ID   string  `json:"id"`
+	Name *string `json:"name,omitempty"`
+}
+
+func installPluginHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, InstallPluginInput) (*mcp.CallToolResult, InstallPluginOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input InstallPluginInput,
+	) (*mcp.CallToolResult, InstallPluginOutput, error) {
+		if input.URL == "" && input.ManifestID == "" {
+			return nil, InstallPluginOutput{}, fmt.Errorf("either url or manifestId is required")
+		}
+
+		source := gen.PluginPackageSource{}
+		if input.URL != "" {
+			source.Url = &input.URL
+		}
+		if input.ManifestID != "" {
+			source.ManifestId = &input.ManifestID
+		}
+
+		resp, err := client.Plugins.InstallPackage(ctx, &gen.InstallPluginPackageInput{
+			Source: source,
+			Force:  input.Force,
+		})
+		if err != nil {
+			return nil, InstallPluginOutput{}, err
+		}
+
+		payload := resp.InstallPluginPackage
+		if payload.Error != nil {
+			errType := "unknown"
+			if tn := (*payload.Error).GetTypename(); tn != nil {
+				errType = *tn
+			}
+			return nil, InstallPluginOutput{}, fmt.Errorf("install plugin failed: %s", errType)
+		}
+		if payload.Package == nil {
+			return nil, InstallPluginOutput{}, fmt.Errorf("install plugin returned no package")
+		}
+
+		return nil, InstallPluginOutput{
+			ID:   payload.Package.Id,
+			Name: payload.Package.Name,
+		}, nil
+	}
+}
+
+func RegisterInstallPluginTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_install_plugin",
+		Description: `Install a Caido plugin package from a url or a store ` +
+			`manifestId. Set force=true to reinstall.`,
+	}, installPluginHandler(client))
+}

--- a/internal/tools/list_finding_reporters.go
+++ b/internal/tools/list_finding_reporters.go
@@ -1,0 +1,42 @@
+package tools
+
+import (
+	"context"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ListFindingReportersInput struct{}
+
+type ListFindingReportersOutput struct {
+	Reporters []string `json:"reporters"`
+}
+
+func listFindingReportersHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, ListFindingReportersInput) (*mcp.CallToolResult, ListFindingReportersOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input ListFindingReportersInput,
+	) (*mcp.CallToolResult, ListFindingReportersOutput, error) {
+		resp, err := client.Findings.ListReporters(ctx)
+		if err != nil {
+			return nil, ListFindingReportersOutput{}, err
+		}
+
+		return nil, ListFindingReportersOutput{
+			Reporters: resp.FindingReporters,
+		}, nil
+	}
+}
+
+func RegisterListFindingReportersTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_list_finding_reporters",
+		Description: `List all finding reporter names (the plugins/sources that have ` +
+			`created findings). Useful as filter values for caido_list_findings.`,
+		InputSchema: map[string]any{"type": "object"},
+	}, listFindingReportersHandler(client))
+}

--- a/internal/tools/list_workflow_node_definitions.go
+++ b/internal/tools/list_workflow_node_definitions.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ListWorkflowNodeDefinitionsInput struct{}
+
+type ListWorkflowNodeDefinitionsOutput struct {
+	Definitions []json.RawMessage `json:"definitions"`
+}
+
+func listWorkflowNodeDefinitionsHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, ListWorkflowNodeDefinitionsInput) (*mcp.CallToolResult, ListWorkflowNodeDefinitionsOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input ListWorkflowNodeDefinitionsInput,
+	) (*mcp.CallToolResult, ListWorkflowNodeDefinitionsOutput, error) {
+		resp, err := client.Workflows.ListNodeDefinitions(ctx)
+		if err != nil {
+			return nil, ListWorkflowNodeDefinitionsOutput{}, err
+		}
+
+		out := ListWorkflowNodeDefinitionsOutput{
+			Definitions: make([]json.RawMessage, 0, len(resp.WorkflowNodeDefinitions)),
+		}
+		for _, d := range resp.WorkflowNodeDefinitions {
+			out.Definitions = append(out.Definitions, d.Raw)
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterListWorkflowNodeDefinitionsTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_list_workflow_node_definitions",
+		Description: `List the available workflow node definitions (the building ` +
+			`blocks for workflow graphs). Use this when constructing a definition ` +
+			`for caido_create_workflow.`,
+		InputSchema: map[string]any{"type": "object"},
+	}, listWorkflowNodeDefinitionsHandler(client))
+}

--- a/internal/tools/list_ws_messages.go
+++ b/internal/tools/list_ws_messages.go
@@ -1,0 +1,175 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	gql "github.com/Khan/genqlient/graphql"
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ListWsMessagesInput is the input for the list_ws_messages tool.
+type ListWsMessagesInput struct {
+	StreamID  string `json:"streamId" jsonschema:"required,WebSocket stream ID (from caido_list_ws_streams)"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"Max messages to return (default 50, max 200)"`
+	After     string `json:"after,omitempty" jsonschema:"Pagination cursor from a previous nextCursor"`
+	BodyLimit int    `json:"bodyLimit,omitempty" jsonschema:"Max bytes of each frame body to return (default 2000)"`
+}
+
+// WsMessageSummary is a single WebSocket frame.
+type WsMessageSummary struct {
+	ID         string `json:"id"`
+	Direction  string `json:"direction"`
+	Format     string `json:"format"`
+	Length     int    `json:"length"`
+	Body       string `json:"body"`
+	Truncated  bool   `json:"truncated,omitempty"`
+	Alteration string `json:"alteration"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+// ListWsMessagesOutput is the output of the list_ws_messages tool.
+type ListWsMessagesOutput struct {
+	Messages   []WsMessageSummary `json:"messages"`
+	HasMore    bool               `json:"hasMore"`
+	NextCursor string             `json:"nextCursor,omitempty"`
+	Total      int                `json:"total"`
+}
+
+type listWsMessagesVars struct {
+	StreamID string  `json:"streamId"`
+	First    int     `json:"first"`
+	After    *string `json:"after"`
+}
+
+type listWsMessagesResp struct {
+	StreamWsMessages struct {
+		Count struct {
+			Value int `json:"value"`
+		} `json:"count"`
+		Edges []struct {
+			Node struct {
+				Id   string `json:"id"`
+				Head struct {
+					Direction  string `json:"direction"`
+					Format     string `json:"format"`
+					Length     int    `json:"length"`
+					Raw        string `json:"raw"`
+					Alteration string `json:"alteration"`
+					CreatedAt  int64  `json:"createdAt"`
+				} `json:"head"`
+			} `json:"node"`
+		} `json:"edges"`
+		PageInfo struct {
+			HasNextPage bool    `json:"hasNextPage"`
+			EndCursor   *string `json:"endCursor"`
+		} `json:"pageInfo"`
+	} `json:"streamWsMessages"`
+}
+
+const listWsMessagesQuery = `
+query ListWsMessages($streamId: ID!, $first: Int, $after: String) {
+	streamWsMessages(streamId: $streamId, first: $first, after: $after, order: {by: ID, ordering: ASC}) {
+		count { value }
+		edges {
+			node {
+				id
+				head { direction format length raw alteration createdAt }
+			}
+		}
+		pageInfo { hasNextPage endCursor }
+	}
+}`
+
+func listWsMessagesHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, ListWsMessagesInput) (*mcp.CallToolResult, ListWsMessagesOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input ListWsMessagesInput,
+	) (*mcp.CallToolResult, ListWsMessagesOutput, error) {
+		if input.StreamID == "" {
+			return nil, ListWsMessagesOutput{}, fmt.Errorf("streamId is required")
+		}
+
+		limit := input.Limit
+		if limit <= 0 {
+			limit = 50
+		}
+		if limit > 200 {
+			limit = 200
+		}
+		bodyLimit := input.BodyLimit
+		if bodyLimit <= 0 {
+			bodyLimit = 2000
+		}
+
+		vars := &listWsMessagesVars{StreamID: input.StreamID, First: limit}
+		if input.After != "" {
+			vars.After = &input.After
+		}
+
+		data := &listWsMessagesResp{}
+		if err := client.GraphQL.MakeRequest(ctx, &gql.Request{
+			OpName:    "ListWsMessages",
+			Query:     listWsMessagesQuery,
+			Variables: vars,
+		}, &gql.Response{Data: data}); err != nil {
+			return nil, ListWsMessagesOutput{}, fmt.Errorf("list ws messages: %w", err)
+		}
+
+		out := ListWsMessagesOutput{
+			Messages: make([]WsMessageSummary, 0, len(data.StreamWsMessages.Edges)),
+			Total:    data.StreamWsMessages.Count.Value,
+		}
+		for _, e := range data.StreamWsMessages.Edges {
+			h := e.Node.Head
+			body, truncated := decodeWsBody(h.Raw, bodyLimit)
+			out.Messages = append(out.Messages, WsMessageSummary{
+				ID:         e.Node.Id,
+				Direction:  h.Direction,
+				Format:     h.Format,
+				Length:     h.Length,
+				Body:       body,
+				Truncated:  truncated,
+				Alteration: h.Alteration,
+				CreatedAt:  time.UnixMilli(h.CreatedAt).Format(time.RFC3339),
+			})
+		}
+		if data.StreamWsMessages.PageInfo.HasNextPage {
+			out.HasMore = true
+			if data.StreamWsMessages.PageInfo.EndCursor != nil {
+				out.NextCursor = *data.StreamWsMessages.PageInfo.EndCursor
+			}
+		}
+
+		return nil, out, nil
+	}
+}
+
+// decodeWsBody base64-decodes a WS frame Blob and truncates it to limit bytes.
+// If decoding fails the raw value is returned as-is.
+func decodeWsBody(raw string, limit int) (string, bool) {
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		decoded = []byte(raw)
+	}
+	if len(decoded) > limit {
+		return string(decoded[:limit]), true
+	}
+	return string(decoded), false
+}
+
+func RegisterListWsMessagesTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_list_ws_messages",
+		Description: `List WebSocket frames for a stream (from caido_list_ws_streams), ` +
+			`like opening a connection in Caido's WebSocket history. Each frame returns ` +
+			`direction (CLIENT/SERVER), format (TEXT/BINARY), length and decoded body. ` +
+			`Bodies are truncated to bodyLimit bytes (default 2000).`,
+	}, listWsMessagesHandler(client))
+}

--- a/internal/tools/list_ws_streams.go
+++ b/internal/tools/list_ws_streams.go
@@ -1,0 +1,144 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gql "github.com/Khan/genqlient/graphql"
+	"github.com/c0tton-fluff/caido-mcp-server/internal/httputil"
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ListWsStreamsInput is the input for the list_ws_streams tool.
+type ListWsStreamsInput struct {
+	ScopeID string `json:"scopeId,omitempty" jsonschema:"Restrict to a scope ID"`
+	Limit   int    `json:"limit,omitempty" jsonschema:"Max streams to return (default 20, max 100)"`
+	After   string `json:"after,omitempty" jsonschema:"Pagination cursor from a previous nextCursor"`
+}
+
+// WsStreamSummary is a single WebSocket connection.
+type WsStreamSummary struct {
+	ID        string `json:"id"`
+	URL       string `json:"url"`
+	Direction string `json:"direction"`
+	Source    string `json:"source"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// ListWsStreamsOutput is the output of the list_ws_streams tool.
+type ListWsStreamsOutput struct {
+	Streams    []WsStreamSummary `json:"streams"`
+	HasMore    bool              `json:"hasMore"`
+	NextCursor string            `json:"nextCursor,omitempty"`
+	Total      int               `json:"total"`
+}
+
+type listWsStreamsVars struct {
+	First int     `json:"first"`
+	After *string `json:"after"`
+	Scope *string `json:"scopeId"`
+}
+
+type listWsStreamsResp struct {
+	Streams struct {
+		Count struct {
+			Value int `json:"value"`
+		} `json:"count"`
+		Edges []struct {
+			Node struct {
+				Id        string `json:"id"`
+				Host      string `json:"host"`
+				Port      int    `json:"port"`
+				Path      string `json:"path"`
+				IsTls     bool   `json:"isTls"`
+				Direction string `json:"direction"`
+				Source    string `json:"source"`
+				CreatedAt int64  `json:"createdAt"`
+			} `json:"node"`
+		} `json:"edges"`
+		PageInfo struct {
+			HasNextPage bool    `json:"hasNextPage"`
+			EndCursor   *string `json:"endCursor"`
+		} `json:"pageInfo"`
+	} `json:"streams"`
+}
+
+const listWsStreamsQuery = `
+query ListWsStreams($first: Int, $after: String, $scopeId: ID) {
+	streams(protocol: WS, first: $first, after: $after, scopeId: $scopeId, order: {by: ID, ordering: ASC}) {
+		count { value }
+		edges {
+			node { id host port path isTls direction source createdAt }
+		}
+		pageInfo { hasNextPage endCursor }
+	}
+}`
+
+func listWsStreamsHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, ListWsStreamsInput) (*mcp.CallToolResult, ListWsStreamsOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input ListWsStreamsInput,
+	) (*mcp.CallToolResult, ListWsStreamsOutput, error) {
+		limit := input.Limit
+		if limit <= 0 {
+			limit = 20
+		}
+		if limit > 100 {
+			limit = 100
+		}
+
+		vars := &listWsStreamsVars{First: limit}
+		if input.After != "" {
+			vars.After = &input.After
+		}
+		if input.ScopeID != "" {
+			vars.Scope = &input.ScopeID
+		}
+
+		data := &listWsStreamsResp{}
+		if err := client.GraphQL.MakeRequest(ctx, &gql.Request{
+			OpName:    "ListWsStreams",
+			Query:     listWsStreamsQuery,
+			Variables: vars,
+		}, &gql.Response{Data: data}); err != nil {
+			return nil, ListWsStreamsOutput{}, fmt.Errorf("list ws streams: %w", err)
+		}
+
+		out := ListWsStreamsOutput{
+			Streams: make([]WsStreamSummary, 0, len(data.Streams.Edges)),
+			Total:   data.Streams.Count.Value,
+		}
+		for _, e := range data.Streams.Edges {
+			n := e.Node
+			out.Streams = append(out.Streams, WsStreamSummary{
+				ID:        n.Id,
+				URL:       httputil.BuildURL(n.IsTls, n.Host, n.Port, n.Path, ""),
+				Direction: n.Direction,
+				Source:    n.Source,
+				CreatedAt: time.UnixMilli(n.CreatedAt).Format(time.RFC3339),
+			})
+		}
+		if data.Streams.PageInfo.HasNextPage {
+			out.HasMore = true
+			if data.Streams.PageInfo.EndCursor != nil {
+				out.NextCursor = *data.Streams.PageInfo.EndCursor
+			}
+		}
+
+		return nil, out, nil
+	}
+}
+
+func RegisterListWsStreamsTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_list_ws_streams",
+		Description: `List WebSocket connections (streams) from history, like the ` +
+			`WebSocket tab in Caido. Returns stream id/url/direction. Use the id with ` +
+			`caido_list_ws_messages to read the frames of a connection.`,
+	}, listWsStreamsHandler(client))
+}

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -9,12 +9,20 @@ func RegisterAll(server *mcp.Server, client *caido.Client) {
 	// HTTP History
 	RegisterListRequestsTool(server, client)
 	RegisterGetRequestTool(server, client)
+	RegisterGetRequestMetadataTool(server, client)
+
+	// WebSocket History
+	RegisterListWsStreamsTool(server, client)
+	RegisterListWsMessagesTool(server, client)
 
 	// Automate (Fuzzing)
 	RegisterListAutomateSessionsTool(server, client)
 	RegisterGetAutomateSessionTool(server, client)
 	RegisterGetAutomateEntryTool(server, client)
 	RegisterAutomateTaskControlTool(server, client)
+	RegisterCreateAutomateSessionTool(server, client)
+	RegisterRenameAutomateSessionTool(server, client)
+	RegisterDeleteAutomateSessionTool(server, client)
 
 	// Replay (Send Requests)
 	RegisterSendRequestTool(server, client)
@@ -28,6 +36,8 @@ func RegisterAll(server *mcp.Server, client *caido.Client) {
 	RegisterGetReplayEntryTool(server, client)
 	RegisterClearSessionCookiesTool(server, client)
 	RegisterGetSessionCookiesTool(server, client)
+	RegisterGetReplaySessionTool(server, client)
+	RegisterRenameReplaySessionTool(server, client)
 
 	// Replay Collections
 	RegisterListReplayCollectionsTool(server, client)
@@ -40,9 +50,17 @@ func RegisterAll(server *mcp.Server, client *caido.Client) {
 	RegisterCreateFindingTool(server, client)
 	RegisterDeleteFindingsTool(server, client)
 	RegisterExportFindingsTool(server, client)
+	RegisterListFindingReportersTool(server, client)
+	RegisterGetFindingTool(server, client)
+
+	// User
+	RegisterWhoamiTool(server, client)
 
 	// Sitemap
 	RegisterGetSitemapTool(server, client)
+	RegisterGetSitemapEntryTool(server, client)
+	RegisterClearSitemapTool(server, client)
+	RegisterDeleteSitemapEntriesTool(server, client)
 
 	// Scopes
 	RegisterListScopesTool(server, client)
@@ -61,6 +79,12 @@ func RegisterAll(server *mcp.Server, client *caido.Client) {
 	RegisterListWorkflowsTool(server, client)
 	RegisterRunWorkflowTool(server, client)
 	RegisterToggleWorkflowTool(server, client)
+	RegisterGetWorkflowTool(server, client)
+	RegisterCreateWorkflowTool(server, client)
+	RegisterRenameWorkflowTool(server, client)
+	RegisterDeleteWorkflowTool(server, client)
+	RegisterSetWorkflowScopeTool(server, client)
+	RegisterListWorkflowNodeDefinitionsTool(server, client)
 
 	// Environments
 	RegisterListEnvironmentsTool(server, client)
@@ -77,6 +101,11 @@ func RegisterAll(server *mcp.Server, client *caido.Client) {
 	RegisterListInterceptEntriesTool(server, client)
 	RegisterForwardInterceptTool(server, client)
 	RegisterDropInterceptTool(server, client)
+	RegisterGetInterceptEntryTool(server, client)
+	RegisterGetInterceptOptionsTool(server, client)
+	RegisterSetInterceptOptionsTool(server, client)
+	RegisterDeleteInterceptEntryTool(server, client)
+	RegisterDeleteInterceptEntriesTool(server, client)
 
 	// Tamper (Match & Replace)
 	RegisterListTamperRulesTool(server, client)
@@ -84,6 +113,9 @@ func RegisterAll(server *mcp.Server, client *caido.Client) {
 	RegisterUpdateTamperRuleTool(server, client)
 	RegisterToggleTamperRuleTool(server, client)
 	RegisterDeleteTamperRuleTool(server, client)
+	RegisterGetTamperRuleTool(server, client)
+	RegisterCreateTamperCollectionTool(server, client)
+	RegisterDeleteTamperCollectionTool(server, client)
 
 	// Filters
 	RegisterListFiltersTool(server, client)
@@ -92,6 +124,8 @@ func RegisterAll(server *mcp.Server, client *caido.Client) {
 
 	// Hosted Files
 	RegisterListHostedFilesTool(server, client)
+	RegisterRenameHostedFileTool(server, client)
+	RegisterDeleteHostedFileTool(server, client)
 
 	// Tasks
 	RegisterListTasksTool(server, client)
@@ -99,4 +133,7 @@ func RegisterAll(server *mcp.Server, client *caido.Client) {
 
 	// Plugins
 	RegisterListPluginsTool(server, client)
+	RegisterInstallPluginTool(server, client)
+	RegisterDeletePluginTool(server, client)
+	RegisterTogglePluginTool(server, client)
 }

--- a/internal/tools/rename_automate_session.go
+++ b/internal/tools/rename_automate_session.go
@@ -1,0 +1,53 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type RenameAutomateSessionInput struct {
+	ID   string `json:"id" jsonschema:"required,Automate session ID"`
+	Name string `json:"name" jsonschema:"required,New session name"`
+}
+
+type RenameAutomateSessionOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func renameAutomateSessionHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, RenameAutomateSessionInput) (*mcp.CallToolResult, RenameAutomateSessionOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input RenameAutomateSessionInput,
+	) (*mcp.CallToolResult, RenameAutomateSessionOutput, error) {
+		resp, err := client.Automate.RenameSession(ctx, input.ID, input.Name)
+		if err != nil {
+			return nil, RenameAutomateSessionOutput{}, fmt.Errorf("rename automate session: %w", err)
+		}
+
+		session := resp.RenameAutomateSession.Session
+		if session == nil {
+			return nil, RenameAutomateSessionOutput{}, fmt.Errorf("rename automate session returned nil")
+		}
+
+		return nil, RenameAutomateSessionOutput{
+			ID:   session.Id,
+			Name: session.Name,
+		}, nil
+	}
+}
+
+func RegisterRenameAutomateSessionTool(
+	server *mcp.Server, client *caido.Client,
+) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_rename_automate_session",
+		Description: `Rename an Automate (fuzzing) session.`,
+	}, renameAutomateSessionHandler(client))
+}

--- a/internal/tools/rename_hosted_file.go
+++ b/internal/tools/rename_hosted_file.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type RenameHostedFileInput struct {
+	ID   string `json:"id" jsonschema:"required,Hosted file ID"`
+	Name string `json:"name" jsonschema:"required,New file name"`
+}
+
+type RenameHostedFileOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func renameHostedFileHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, RenameHostedFileInput) (*mcp.CallToolResult, RenameHostedFileOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input RenameHostedFileInput,
+	) (*mcp.CallToolResult, RenameHostedFileOutput, error) {
+		resp, err := client.HostedFiles.Rename(ctx, input.ID, input.Name)
+		if err != nil {
+			return nil, RenameHostedFileOutput{}, err
+		}
+
+		file := resp.RenameHostedFile.HostedFile
+		if file == nil {
+			return nil, RenameHostedFileOutput{}, fmt.Errorf("rename hosted file returned nil")
+		}
+
+		return nil, RenameHostedFileOutput{
+			ID:   file.Id,
+			Name: file.Name,
+		}, nil
+	}
+}
+
+func RegisterRenameHostedFileTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_rename_hosted_file",
+		Description: `Rename a hosted file.`,
+	}, renameHostedFileHandler(client))
+}

--- a/internal/tools/rename_replay_session.go
+++ b/internal/tools/rename_replay_session.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type RenameReplaySessionInput struct {
+	ID   string `json:"id" jsonschema:"required,Replay session ID"`
+	Name string `json:"name" jsonschema:"required,New session name"`
+}
+
+type RenameReplaySessionOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func renameReplaySessionHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, RenameReplaySessionInput) (*mcp.CallToolResult, RenameReplaySessionOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input RenameReplaySessionInput,
+	) (*mcp.CallToolResult, RenameReplaySessionOutput, error) {
+		resp, err := client.Replay.RenameSession(ctx, input.ID, input.Name)
+		if err != nil {
+			return nil, RenameReplaySessionOutput{}, fmt.Errorf("rename replay session: %w", err)
+		}
+
+		session := resp.RenameReplaySession.Session
+		if session == nil {
+			return nil, RenameReplaySessionOutput{}, fmt.Errorf("rename replay session returned nil")
+		}
+
+		return nil, RenameReplaySessionOutput{
+			ID:   session.Id,
+			Name: session.Name,
+		}, nil
+	}
+}
+
+func RegisterRenameReplaySessionTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_rename_replay_session",
+		Description: `Rename a replay session.`,
+	}, renameReplaySessionHandler(client))
+}

--- a/internal/tools/rename_workflow.go
+++ b/internal/tools/rename_workflow.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type RenameWorkflowInput struct {
+	ID   string `json:"id" jsonschema:"required,Workflow ID"`
+	Name string `json:"name" jsonschema:"required,New workflow name"`
+}
+
+type RenameWorkflowOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func renameWorkflowHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, RenameWorkflowInput) (*mcp.CallToolResult, RenameWorkflowOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input RenameWorkflowInput,
+	) (*mcp.CallToolResult, RenameWorkflowOutput, error) {
+		resp, err := client.Workflows.Rename(ctx, input.ID, input.Name)
+		if err != nil {
+			return nil, RenameWorkflowOutput{}, err
+		}
+
+		payload := resp.RenameWorkflow
+		if payload.Error != nil {
+			errType := "unknown"
+			if tn := (*payload.Error).GetTypename(); tn != nil {
+				errType = *tn
+			}
+			return nil, RenameWorkflowOutput{}, fmt.Errorf("rename workflow failed: %s", errType)
+		}
+		if payload.Workflow == nil {
+			return nil, RenameWorkflowOutput{}, fmt.Errorf("rename workflow returned no workflow")
+		}
+
+		return nil, RenameWorkflowOutput{
+			ID:   payload.Workflow.Id,
+			Name: payload.Workflow.Name,
+		}, nil
+	}
+}
+
+func RegisterRenameWorkflowTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_rename_workflow",
+		Description: `Rename a workflow.`,
+	}, renameWorkflowHandler(client))
+}

--- a/internal/tools/schema_test.go
+++ b/internal/tools/schema_test.go
@@ -40,7 +40,7 @@ func TestToolCount(t *testing.T) {
 		t.Fatalf("ListTools failed: %v", err)
 	}
 
-	const expectedTools = 60
+	const expectedTools = 93
 	if len(result.Tools) != expectedTools {
 		t.Fatalf("want %d tools registered, got %d", expectedTools, len(result.Tools))
 	}

--- a/internal/tools/set_intercept_options.go
+++ b/internal/tools/set_intercept_options.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"context"
+
+	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type SetInterceptOptionsInput struct {
+	RequestEnabled  bool    `json:"requestEnabled" jsonschema:"required,Intercept requests"`
+	ResponseEnabled bool    `json:"responseEnabled" jsonschema:"required,Intercept responses"`
+	StreamWsEnabled bool    `json:"streamWsEnabled,omitempty" jsonschema:"Intercept WebSocket streams (default false)"`
+	ScopeID         *string `json:"scopeId,omitempty" jsonschema:"Restrict interception to this scope ID (omit for all traffic)"`
+}
+
+type SetInterceptOptionsOutput struct {
+	RequestEnabled  bool `json:"requestEnabled"`
+	ResponseEnabled bool `json:"responseEnabled"`
+}
+
+func setInterceptOptionsHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, SetInterceptOptionsInput) (*mcp.CallToolResult, SetInterceptOptionsOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input SetInterceptOptionsInput,
+	) (*mcp.CallToolResult, SetInterceptOptionsOutput, error) {
+		optsInput := gen.InterceptOptionsInput{
+			Request: gen.InterceptRequestOptionsInput{
+				Enabled: input.RequestEnabled,
+			},
+			Response: gen.InterceptResponseOptionsInput{
+				Enabled: input.ResponseEnabled,
+			},
+			StreamWs: gen.InterceptStreamWsOptionsInput{
+				Enabled: input.StreamWsEnabled,
+			},
+		}
+		if input.ScopeID != nil && *input.ScopeID != "" {
+			optsInput.Scope = &gen.InterceptScopeOptionsInput{
+				ScopeId: *input.ScopeID,
+			}
+		}
+
+		resp, err := client.Intercept.SetOptions(ctx, &optsInput)
+		if err != nil {
+			return nil, SetInterceptOptionsOutput{}, err
+		}
+
+		opts := resp.SetInterceptOptions.Options
+		return nil, SetInterceptOptionsOutput{
+			RequestEnabled:  opts.Request.Enabled,
+			ResponseEnabled: opts.Response.Enabled,
+		}, nil
+	}
+}
+
+func RegisterSetInterceptOptionsTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_set_intercept_options",
+		Description: `Configure the intercept proxy: toggle request/response/WebSocket ` +
+			`interception and optionally restrict it to a scope. Note: this does not ` +
+			`pause/resume interception itself (use caido_intercept_control).`,
+	}, setInterceptOptionsHandler(client))
+}

--- a/internal/tools/set_workflow_scope.go
+++ b/internal/tools/set_workflow_scope.go
@@ -1,0 +1,83 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type SetWorkflowScopeInput struct {
+	ID     string `json:"id" jsonschema:"required,Workflow ID"`
+	Global bool   `json:"global" jsonschema:"required,true to globalize (share across projects), false to localize to the current project"`
+}
+
+type SetWorkflowScopeOutput struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Global bool   `json:"global"`
+}
+
+func setWorkflowScopeHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, SetWorkflowScopeInput) (*mcp.CallToolResult, SetWorkflowScopeOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input SetWorkflowScopeInput,
+	) (*mcp.CallToolResult, SetWorkflowScopeOutput, error) {
+		if input.Global {
+			resp, err := client.Workflows.Globalize(ctx, input.ID)
+			if err != nil {
+				return nil, SetWorkflowScopeOutput{}, err
+			}
+			payload := resp.GlobalizeWorkflow
+			if payload.Error != nil {
+				errType := "unknown"
+				if tn := (*payload.Error).GetTypename(); tn != nil {
+					errType = *tn
+				}
+				return nil, SetWorkflowScopeOutput{}, fmt.Errorf("globalize workflow failed: %s", errType)
+			}
+			if payload.Workflow == nil {
+				return nil, SetWorkflowScopeOutput{}, fmt.Errorf("globalize workflow returned no workflow")
+			}
+			return nil, SetWorkflowScopeOutput{
+				ID:     payload.Workflow.Id,
+				Name:   payload.Workflow.Name,
+				Global: payload.Workflow.Global,
+			}, nil
+		}
+
+		resp, err := client.Workflows.Localize(ctx, input.ID)
+		if err != nil {
+			return nil, SetWorkflowScopeOutput{}, err
+		}
+		payload := resp.LocalizeWorkflow
+		if payload.Error != nil {
+			errType := "unknown"
+			if tn := (*payload.Error).GetTypename(); tn != nil {
+				errType = *tn
+			}
+			return nil, SetWorkflowScopeOutput{}, fmt.Errorf("localize workflow failed: %s", errType)
+		}
+		if payload.Workflow == nil {
+			return nil, SetWorkflowScopeOutput{}, fmt.Errorf("localize workflow returned no workflow")
+		}
+		return nil, SetWorkflowScopeOutput{
+			ID:     payload.Workflow.Id,
+			Name:   payload.Workflow.Name,
+			Global: payload.Workflow.Global,
+		}, nil
+	}
+}
+
+func RegisterSetWorkflowScopeTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_set_workflow_scope",
+		Description: `Change a workflow's scope: globalize (global=true) to share it ` +
+			`across all projects, or localize (global=false) to bind it to the ` +
+			`current project.`,
+	}, setWorkflowScopeHandler(client))
+}

--- a/internal/tools/toggle_plugin.go
+++ b/internal/tools/toggle_plugin.go
@@ -1,0 +1,59 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	caido "github.com/caido-community/sdk-go"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type TogglePluginInput struct {
+	ID      string `json:"id" jsonschema:"required,Plugin ID"`
+	Enabled bool   `json:"enabled" jsonschema:"required,Enable (true) or disable (false) the plugin"`
+}
+
+type TogglePluginOutput struct {
+	ID      string `json:"id"`
+	Enabled bool   `json:"enabled"`
+}
+
+func togglePluginHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, TogglePluginInput) (*mcp.CallToolResult, TogglePluginOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input TogglePluginInput,
+	) (*mcp.CallToolResult, TogglePluginOutput, error) {
+		resp, err := client.Plugins.Toggle(ctx, input.ID, input.Enabled)
+		if err != nil {
+			return nil, TogglePluginOutput{}, err
+		}
+
+		payload := resp.TogglePlugin
+		if payload.Error != nil {
+			errType := "unknown"
+			if tn := (*payload.Error).GetTypename(); tn != nil {
+				errType = *tn
+			}
+			return nil, TogglePluginOutput{}, fmt.Errorf("toggle plugin failed: %s", errType)
+		}
+		if payload.Plugin == nil {
+			return nil, TogglePluginOutput{}, fmt.Errorf("toggle plugin returned no plugin")
+		}
+
+		plugin := *payload.Plugin
+		return nil, TogglePluginOutput{
+			ID:      plugin.GetId(),
+			Enabled: plugin.GetEnabled(),
+		}, nil
+	}
+}
+
+func RegisterTogglePluginTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "caido_toggle_plugin",
+		Description: `Enable or disable an installed plugin by ID.`,
+	}, togglePluginHandler(client))
+}

--- a/internal/tools/whoami.go
+++ b/internal/tools/whoami.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"context"
+
+	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type WhoamiInput struct{}
+
+type WhoamiOutput struct {
+	Kind  string `json:"kind"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
+func whoamiHandler(
+	client *caido.Client,
+) func(context.Context, *mcp.CallToolRequest, WhoamiInput) (*mcp.CallToolResult, WhoamiOutput, error) {
+	return func(
+		ctx context.Context,
+		req *mcp.CallToolRequest,
+		input WhoamiInput,
+	) (*mcp.CallToolResult, WhoamiOutput, error) {
+		resp, err := client.Users.GetViewer(ctx)
+		if err != nil {
+			return nil, WhoamiOutput{}, err
+		}
+
+		out := WhoamiOutput{}
+		switch u := resp.Viewer.(type) {
+		case *gen.GetViewerViewerCloudUser:
+			out.Kind = "cloud"
+			out.ID = u.Id
+			out.Name = u.Profile.Identity.Name
+			out.Email = u.Profile.Identity.Email
+		case *gen.GetViewerViewerGuestUser:
+			out.Kind = "guest"
+		case *gen.GetViewerViewerScriptUser:
+			out.Kind = "script"
+		default:
+			out.Kind = "unknown"
+		}
+		return nil, out, nil
+	}
+}
+
+func RegisterWhoamiTool(server *mcp.Server, client *caido.Client) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "caido_whoami",
+		Description: `Get the currently authenticated Caido user (kind: cloud/guest/script, ` +
+			`plus name and email for cloud users).`,
+		InputSchema: map[string]any{"type": "object"},
+	}, whoamiHandler(client))
+}


### PR DESCRIPTION
## Summary

Expands MCP tool coverage from **60 to 93 tools**, closing the remaining gaps between the Caido Go SDK and the MCP surface, and adding **read access to WebSocket traffic** (the WebSocket tab in Caido), which was previously not exposed at all.

Every Caido SDK operation of practical value for pentesting is now reachable through MCP. WebSocket history is implemented via raw GraphQL (`client.GraphQL.MakeRequest`) because the SDK v0.5.0 does not wrap those queries — the same approach already used by `create_tamper_rule`.

## New tools by area

**Automate / fuzzing (3)** — full session lifecycle (previously only list/read/control):
- `caido_create_automate_session` — seed a session from a request ID or raw HTTP
- `caido_rename_automate_session`, `caido_delete_automate_session`

**Workflows (6)** — beyond list/run/toggle:
- `caido_get_workflow` — inspect the node-graph definition
- `caido_create_workflow` — create from a JSON definition
- `caido_rename_workflow`, `caido_delete_workflow`
- `caido_set_workflow_scope` — globalize / localize
- `caido_list_workflow_node_definitions`

**Plugins (3):** `caido_install_plugin` (url or store manifest), `caido_delete_plugin`, `caido_toggle_plugin`

**Hosted files (2):** `caido_rename_hosted_file`, `caido_delete_hosted_file`

**Intercept (5):**
- `caido_get_intercept_entry` — single entry with request/response
- `caido_get_intercept_options`, `caido_set_intercept_options`
- `caido_delete_intercept_entry`, `caido_delete_intercept_entries` (HTTPQL filter)

**Sitemap (3):** `caido_get_sitemap_entry`, `caido_clear_sitemap`, `caido_delete_sitemap_entries`

**Tamper (3):** `caido_create_tamper_collection`, `caido_delete_tamper_collection`, `caido_get_tamper_rule`

**Findings (2):** `caido_get_finding`, `caido_list_finding_reporters`

**Replay sessions (2):** `caido_get_replay_session`, `caido_rename_replay_session`

**Requests (1):** `caido_get_request_metadata` — lightweight metadata without raw bodies

**User (1):** `caido_whoami`

**WebSocket history (2)** — read traffic like the WebSocket tab:
- `caido_list_ws_streams` — WebSocket connections (streams)
- `caido_list_ws_messages` — frames of a stream (direction CLIENT/SERVER, format TEXT/BINARY, decoded body, truncated to `bodyLimit`)

## Implementation notes

- Each tool follows the existing pattern: `Input`/`Output` structs with `jsonschema` tags, a handler closure over `*caido.Client`, and GraphQL error handling via `GetTypename()`.
- WebSocket tools use raw GraphQL queries against `streams(protocol: WS, ...)` and `streamWsMessages(streamId, ...)`; field names and scalar mappings (`Timestamp` -> int64, `Blob` -> base64 string) were taken from the bundled `schema.graphql`.
- Combined globalize/localize into a single `set_workflow_scope` tool with a `global` flag.
- Deliberately skipped instance settings (onboarding/analytics/AI-provider only — not useful for pentesting) and WebSocket frame interception/editing (out of scope for read-only history).

## Testing

- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — all packages pass; `internal/tools/schema_test.go` asserts the tool count (updated 60 -> 93) and that every tool has a non-empty description and input schema
- Not verified against a live Caido instance: the WebSocket GraphQL queries are written strictly against the bundled schema but have not been exercised at runtime against a server with active WS traffic.

## Docs

- `README.md`: tool table and counts updated
- `CHANGELOG.md`: 4.0.0 entry