### PR TITLE
refactor: WS tools use sdk-go StreamSDK wrappers instead of raw GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
 ### Internal
 - Documented the genqlient v0.8.1 oneof/omitempty limitation in `create_tamper_rule.go` as an upstream constraint (the `delete_findings`/`export_findings` tools use clean typed structs and need no workaround).
 
+### Changed (SDK alignment)
+- Added WebSocket/stream read queries to `caido-community/sdk-go` (new `StreamSDK`: `List`, `Get`, `ListWsMessages`) and bumped this server to that SDK build. `caido_list_ws_streams` and `caido_list_ws_messages` now use the typed SDK wrappers instead of hand-rolled raw GraphQL.
+
 ## [3.0.0] - 2026-05-21
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Khan/genqlient v0.8.1
-	github.com/caido-community/sdk-go v0.5.0
+	github.com/caido-community/sdk-go v0.5.1-0.20260602103949-e8477aca6469
 	github.com/gorilla/websocket v1.5.3
 	github.com/modelcontextprotocol/go-sdk v1.2.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/caido-community/sdk-go v0.5.0 h1:oU4iwBN4bKvDBsJU6qE8j+laFcyyVHHE2uPll/Q0Ru4=
-github.com/caido-community/sdk-go v0.5.0/go.mod h1:7O5FNuZJAaXqUNI/DXxuT1KwJZnCKZUFbJ+dbfhZ3hY=
+github.com/caido-community/sdk-go v0.5.1-0.20260602103949-e8477aca6469 h1:y02CbyEHZ9PBF/1z7jEA86uMdC6b7KlpuulvlT1Qxb8=
+github.com/caido-community/sdk-go v0.5.1-0.20260602103949-e8477aca6469/go.mod h1:7O5FNuZJAaXqUNI/DXxuT1KwJZnCKZUFbJ+dbfhZ3hY=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/tools/list_ws_messages.go
+++ b/internal/tools/list_ws_messages.go
@@ -5,57 +5,13 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	gql "github.com/Khan/genqlient/graphql"
 	caido "github.com/caido-community/sdk-go"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// WebSocket frame content lives on StreamWsMessage.head (a StreamWsMessageEdit
-// in the bundled schema): direction (StreamMessageDirection CLIENT/SERVER),
-// format (StreamWsMessageFormat TEXT/BINARY), length, and raw (a Blob, which
-// the API serializes as base64 -- decoded here like the other Blob tools).
-// Issued as raw GraphQL since the Go SDK v0.5.0 does not wrap stream queries.
-
-type listWsMessagesVars struct {
-	StreamID string  `json:"streamId"`
-	First    int     `json:"first"`
-	After    *string `json:"after,omitempty"`
-}
-
-type listWsMessagesResp struct {
-	StreamWsMessages struct {
-		Edges []struct {
-			Cursor string `json:"cursor"`
-			Node   struct {
-				ID   string `json:"id"`
-				Head struct {
-					Direction string `json:"direction"`
-					Format    string `json:"format"`
-					Length    int    `json:"length"`
-					Raw       string `json:"raw"`
-				} `json:"head"`
-			} `json:"node"`
-		} `json:"edges"`
-		PageInfo struct {
-			HasNextPage bool    `json:"hasNextPage"`
-			EndCursor   *string `json:"endCursor"`
-		} `json:"pageInfo"`
-	} `json:"streamWsMessages"`
-}
-
-const listWsMessagesQuery = `
-query ListWsMessages($streamId: ID!, $first: Int!, $after: String) {
-	streamWsMessages(streamId: $streamId, first: $first, after: $after) {
-		edges {
-			cursor
-			node {
-				id
-				head { direction format length raw }
-			}
-		}
-		pageInfo { hasNextPage endCursor }
-	}
-}`
+// WebSocket frame content lives on each message's head field (a
+// StreamWsMessageEdit): direction (CLIENT/SERVER), format (TEXT/BINARY),
+// length, and raw (a Blob the API serializes as base64, decoded here).
 
 // ListWsMessagesInput is the input for the list_ws_messages tool
 type ListWsMessagesInput struct {
@@ -112,37 +68,30 @@ func listWsMessagesHandler(
 			bodyLimit = 65536
 		}
 
-		vars := &listWsMessagesVars{StreamID: input.StreamID, First: limit}
+		opts := &caido.ListWsMessagesOptions{First: &limit}
 		if input.After != "" {
-			vars.After = &input.After
+			opts.After = &input.After
 		}
 
-		gqlReq := &gql.Request{
-			OpName:    "ListWsMessages",
-			Query:     listWsMessagesQuery,
-			Variables: vars,
-		}
-		data := &listWsMessagesResp{}
-		if err := client.GraphQL.MakeRequest(
-			ctx, gqlReq, &gql.Response{Data: data},
-		); err != nil {
+		resp, err := client.Streams.ListWsMessages(ctx, input.StreamID, opts)
+		if err != nil {
 			return nil, ListWsMessagesOutput{}, fmt.Errorf(
 				"failed to list ws messages: %w", err,
 			)
 		}
 
-		conn := data.StreamWsMessages
+		conn := resp.StreamWsMessages
 		output := ListWsMessagesOutput{
 			Messages: make([]WsMessageSummary, 0, len(conn.Edges)),
 		}
 		for _, edge := range conn.Edges {
-			n := edge.Node
-			body, truncated := decodeWsBody(n.Head.Raw, bodyLimit)
+			head := edge.Node.Head
+			body, truncated := decodeWsBody(head.Raw, bodyLimit)
 			output.Messages = append(output.Messages, WsMessageSummary{
-				ID:        n.ID,
-				Direction: n.Head.Direction,
-				Format:    n.Head.Format,
-				Length:    n.Head.Length,
+				ID:        edge.Node.Id,
+				Direction: string(head.Direction),
+				Format:    string(head.Format),
+				Length:    head.Length,
 				Body:      body,
 				Truncated: truncated,
 			})

--- a/internal/tools/list_ws_streams.go
+++ b/internal/tools/list_ws_streams.go
@@ -4,55 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	gql "github.com/Khan/genqlient/graphql"
 	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
-
-// The Go SDK v0.5.0 does not wrap WebSocket (stream) queries, so we issue
-// raw GraphQL via client.GraphQL.MakeRequest -- the same approach used by
-// create_tamper_rule.go. Field names and the WS protocol enum are taken
-// from the bundled graphql/schema.graphql (type Stream, enum StreamProtocol).
-
-type listWsStreamsVars struct {
-	First    int     `json:"first"`
-	After    *string `json:"after,omitempty"`
-	Protocol string  `json:"protocol"`
-	ScopeID  *string `json:"scopeId,omitempty"`
-}
-
-type listWsStreamsResp struct {
-	Streams struct {
-		Edges []struct {
-			Cursor string `json:"cursor"`
-			Node   struct {
-				ID        string `json:"id"`
-				Host      string `json:"host"`
-				Port      int    `json:"port"`
-				Path      string `json:"path"`
-				IsTls     bool   `json:"isTls"`
-				Direction string `json:"direction"`
-				Source    string `json:"source"`
-				CreatedAt int64  `json:"createdAt"`
-			} `json:"node"`
-		} `json:"edges"`
-		PageInfo struct {
-			HasNextPage bool    `json:"hasNextPage"`
-			EndCursor   *string `json:"endCursor"`
-		} `json:"pageInfo"`
-	} `json:"streams"`
-}
-
-const listWsStreamsQuery = `
-query ListWsStreams($first: Int!, $after: String, $protocol: StreamProtocol!, $scopeId: ID) {
-	streams(first: $first, after: $after, protocol: $protocol, scopeId: $scopeId) {
-		edges {
-			cursor
-			node { id host port path isTls direction source createdAt }
-		}
-		pageInfo { hasNextPage endCursor }
-	}
-}`
 
 // ListWsStreamsInput is the input for the list_ws_streams tool
 type ListWsStreamsInput struct {
@@ -96,42 +51,38 @@ func listWsStreamsHandler(
 			limit = 100
 		}
 
-		vars := &listWsStreamsVars{First: limit, Protocol: "WS"}
+		opts := &caido.ListStreamsOptions{
+			First:    &limit,
+			Protocol: gen.StreamProtocolWs,
+		}
 		if input.After != "" {
-			vars.After = &input.After
+			opts.After = &input.After
 		}
 		if input.ScopeID != "" {
-			vars.ScopeID = &input.ScopeID
+			opts.ScopeID = &input.ScopeID
 		}
 
-		gqlReq := &gql.Request{
-			OpName:    "ListWsStreams",
-			Query:     listWsStreamsQuery,
-			Variables: vars,
-		}
-		data := &listWsStreamsResp{}
-		if err := client.GraphQL.MakeRequest(
-			ctx, gqlReq, &gql.Response{Data: data},
-		); err != nil {
+		resp, err := client.Streams.List(ctx, opts)
+		if err != nil {
 			return nil, ListWsStreamsOutput{}, fmt.Errorf(
 				"failed to list ws streams: %w", err,
 			)
 		}
 
-		conn := data.Streams
+		conn := resp.Streams
 		output := ListWsStreamsOutput{
 			Streams: make([]WsStreamSummary, 0, len(conn.Edges)),
 		}
 		for _, edge := range conn.Edges {
 			n := edge.Node
 			output.Streams = append(output.Streams, WsStreamSummary{
-				ID:        n.ID,
+				ID:        n.Id,
 				Host:      n.Host,
 				Port:      n.Port,
 				Path:      n.Path,
 				IsTLS:     n.IsTls,
-				Direction: n.Direction,
-				Source:    n.Source,
+				Direction: string(n.Direction),
+				Source:    string(n.Source),
 				CreatedAt: n.CreatedAt,
 			})
 		}

--- a/internal/tools/websocket_test.go
+++ b/internal/tools/websocket_test.go
@@ -17,7 +17,7 @@ func b64(s string) string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
 }
 
-// streamsData builds the "streams" connection payload for OpName ListWsStreams.
+// streamsData builds the "streams" connection payload for OpName ListStreams.
 // hasNext drives pagination; endCursor is only meaningful when hasNext is true.
 func streamsData(hasNext bool, endCursor string, ids ...string) map[string]any {
 	edges := make([]map[string]any, len(ids))
@@ -52,7 +52,7 @@ func streamsData(hasNext bool, endCursor string, ids ...string) map[string]any {
 }
 
 // wsMessagesData builds the "streamWsMessages" connection payload for OpName
-// ListWsMessages. raw is provided already base64-encoded.
+// ListStreamWsMessages. raw is provided already base64-encoded.
 func wsMessagesData(hasNext bool, endCursor string, raws ...string) map[string]any {
 	edges := make([]map[string]any, len(raws))
 	for i, raw := range raws {
@@ -131,7 +131,7 @@ func TestListWsStreamsTool(t *testing.T) {
 				tools.RegisterListWsStreamsTool(s, c)
 			})
 			if tt.registerOp {
-				env.Mock.On("ListWsStreams", tt.mock)
+				env.Mock.On("ListStreams", tt.mock)
 			}
 
 			result := env.CallTool(t, "caido_list_ws_streams", tt.input)
@@ -233,7 +233,7 @@ func TestListWsMessagesTool(t *testing.T) {
 				tools.RegisterListWsMessagesTool(s, c)
 			})
 			if tt.registerOp {
-				env.Mock.On("ListWsMessages", tt.mock)
+				env.Mock.On("ListStreamWsMessages", tt.mock)
 			}
 
 			result := env.CallTool(t, "caido_list_ws_messages", tt.input)


### PR DESCRIPTION
## Summary

Follow-up to the WebSocket history tools. Now that `caido-community/sdk-go` exposes stream queries via `StreamSDK` (added in caido-community/sdk-go#5), this swaps the hand-rolled raw GraphQL in the two WS tools for typed SDK calls.

## Changes

- Bumped `caido-community/sdk-go` to the build that includes `StreamSDK` (`v0.5.1-0.20260602103949-e8477aca6469`)
- `caido_list_ws_streams` -> `client.Streams.List` (protocol defaults to WS)
- `caido_list_ws_messages` -> `client.Streams.ListWsMessages`
- Output structs and tool behavior unchanged; base64 `Blob` body decode + `body_limit` truncation preserved
- Test mock operation names updated to the SDK's `ListStreams` / `ListStreamWsMessages`

Net -97 LOC (removed the raw GraphQL query strings, variable wrappers, and response structs).

## Testing

- `go build ./...`, `go vet ./...` - clean
- `go test ./... -race -count=1` - all pass
- gofmt clean

Depends on caido-community/sdk-go#5 (merged).