### PR TITLE
fix(replay): expose required 'kind' field on create_replay_session

### DIFF
--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	caido "github.com/caido-community/sdk-go"
+	gen "github.com/caido-community/sdk-go/graphql"
 )
 
 const (
@@ -37,7 +38,12 @@ func GetOrCreateSession(
 	if defaultSessionID != "" {
 		return defaultSessionID, nil
 	}
-	sessionID, _, err := client.Replay.CreateSession(ctx, nil)
+	// Caido 0.57 GraphQL contract requires kind on CreateReplaySession.
+	// Pass an explicit HTTP default instead of nil so we don't rely on
+	// sdk-go's empty-string fallback (fragile across SDK pins).
+	sessionID, _, err := client.Replay.CreateSession(
+		ctx, &gen.CreateReplaySessionInput{Kind: gen.ReplaySessionKindHttp},
+	)
 	if err != nil {
 		return "", fmt.Errorf("create replay session: %w", err)
 	}

--- a/internal/tools/create_replay_session.go
+++ b/internal/tools/create_replay_session.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	caido "github.com/caido-community/sdk-go"
 	gen "github.com/caido-community/sdk-go/graphql"
@@ -13,6 +14,7 @@ type CreateReplaySessionInput struct {
 	Name            string `json:"name,omitempty" jsonschema:"Session name (applied via rename after creation)"`
 	CollectionID    string `json:"collectionId,omitempty" jsonschema:"Collection ID to assign the session to"`
 	RequestSourceID string `json:"requestSourceId,omitempty" jsonschema:"Existing request ID to seed the session with"`
+	Kind            string `json:"kind,omitempty" jsonschema:"Session kind - allowed values: HTTP (default) or WS for WebSocket replay"`
 }
 
 type CreateReplaySessionOutput struct {
@@ -28,7 +30,21 @@ func createReplaySessionHandler(
 		req *mcp.CallToolRequest,
 		input CreateReplaySessionInput,
 	) (*mcp.CallToolResult, CreateReplaySessionOutput, error) {
-		createInput := &gen.CreateReplaySessionInput{}
+		// CreateReplaySessionInput.kind is a required GraphQL field per Caido 0.57 schema.
+		// Force HTTP default explicitly so we don't depend on sdk-go's empty-string default,
+		// which can disappear across SDK pins or when backend tightens validation.
+		kind := gen.ReplaySessionKindHttp
+		switch strings.ToUpper(strings.TrimSpace(input.Kind)) {
+		case "", "HTTP":
+			// keep default HTTP
+		case "WS":
+			kind = gen.ReplaySessionKindWs
+		default:
+			return nil, CreateReplaySessionOutput{}, fmt.Errorf(
+				"invalid kind %q (allowed: HTTP, WS)", input.Kind,
+			)
+		}
+		createInput := &gen.CreateReplaySessionInput{Kind: kind}
 
 		if input.CollectionID != "" {
 			createInput.CollectionId = &input.CollectionID

--- a/internal/tools/create_replay_session_test.go
+++ b/internal/tools/create_replay_session_test.go
@@ -54,6 +54,36 @@ func TestCreateReplaySession(t *testing.T) {
 			wantID:   "sess-col",
 			wantName: "api-tests",
 		},
+		{
+			name: "creates HTTP session via explicit kind",
+			args: map[string]any{"kind": "HTTP"},
+			setup: func(m *testutil.MockHandler) {
+				m.On("CreateReplaySession", testutil.CreateReplaySessionResponse("sess-http"))
+			},
+			wantID: "sess-http",
+		},
+		{
+			name: "creates WS session via explicit kind",
+			args: map[string]any{"kind": "WS"},
+			setup: func(m *testutil.MockHandler) {
+				m.On("CreateReplaySession", testutil.CreateReplaySessionResponse("sess-ws"))
+			},
+			wantID: "sess-ws",
+		},
+		{
+			name: "creates session with lowercase kind (normalized)",
+			args: map[string]any{"kind": "ws"},
+			setup: func(m *testutil.MockHandler) {
+				m.On("CreateReplaySession", testutil.CreateReplaySessionResponse("sess-ws-lower"))
+			},
+			wantID: "sess-ws-lower",
+		},
+		{
+			name:    "rejects invalid kind value",
+			args:    map[string]any{"kind": "FTP"},
+			setup:   func(m *testutil.MockHandler) {},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`caido_create_replay_session` (and transitively `caido_send_request` when seeding a fresh default session via `GetOrCreateSession`) fails because the Caido GraphQL backend requires `kind: ReplaySessionKind!`. The MCP tool never exposed nor forced this field, relying on sdk-go's empty-string default — which is fragile across SDK pins or when the backend tightens schema validation. As a bonus, WS replay testing is impossible from MCP clients today because `Kind` is hidden.

Observed in a real engagement with Caido 0.57 + caido-mcp-server v4.1.0: `caido:caido_create_replay_session name=...` errored out at the GraphQL layer because `kind` was absent in the mutation payload, despite sdk-go pinning at `v0.5.1-0.20260610122908`.

## Changes

- **`internal/tools/create_replay_session.go`** — expose `Kind` on the input schema with documented allowed values (`HTTP` / `WS`). Normalize input to upper-case + trim whitespace, default to `HTTP` when empty, and fail fast with an explicit error on unknown values.
- **`internal/replay/replay.go`** — `GetOrCreateSession` now passes an explicit `&gen.CreateReplaySessionInput{Kind: gen.ReplaySessionKindHttp}` instead of `nil`, so the cascading `caido_send_request` path doesn't depend on sdk-go's empty-string fallback either.
- **`internal/tools/create_replay_session_test.go`** — coverage for `kind=HTTP`, `kind=WS`, lowercase normalization, and invalid-value rejection.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/tools/... ./internal/replay/...` passes (including 4 new sub-tests on the create_replay_session table)
- [x] Manual: created sessions without `kind` (default HTTP), with `kind=WS`, with `kind=XYZ` (validation error fires before reaching backend). Confirmed against Caido 0.57 desktop client.
- [ ] Reviewer should verify WS session creation end-to-end if they have a WS upstream available.

## Notes

- No behavior change for existing callers — empty `kind` still defaults to HTTP, matching prior behavior.
- The handler-layer validation is intentional belt-and-suspenders alongside the GraphQL enum: if a future sdk-go bump changes the default or removes it, this stays safe.
- No changes to GraphQL schema, sdk-go version pin, or public tool catalog.