### PR TITLE
feat: opt out of sensitive header redaction via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Both share the same auth token, the same Go SDK, and the same codebase.
 
 **Built-in security and performance:**
 
-- Credential redaction - Authorization, Cookie, and API key headers are redacted in tool output
+- Credential redaction - Authorization, Cookie, and API key headers are redacted in tool output by default; opt out with `CAIDO_MCP_ALLOW_SENSITIVE` (see [Revealing sensitive headers](#revealing-sensitive-headers))
 - Session cookie jar - RFC 6265 jar per replay session; `Set-Cookie` from a response is auto-attached to the next `send_request` against the same session
 - Response fingerprinting - auto-detects content kind (json/html/xml/text/binary) so agents know what they're dealing with
 - Adaptive body limits - JSON gets 4KB, HTML 3KB, binary 200B (override with explicit `bodyLimit`)
@@ -64,6 +64,27 @@ Both share the same auth token, the same Go SDK, and the same codebase.
 The `caido_send_request` tool maintains an in-memory `http.CookieJar` per replay session. Cookies set via `Set-Cookie` in any response are stored and auto-injected into subsequent requests targeting the same RFC 6265 domain/path. Pass `useCookieJar: false` to a single call to disable injection (useful for session-fixation testing or to verify auth gates). Use `caido_clear_session_cookies` to wipe a session jar between test runs and `caido_get_session_cookies` to introspect what is stored (cookie values are not returned, only metadata).
 
 The output of `caido_send_request` includes a `cookieJar` block with `injectedCookies` (names sent on this call) and `storedCookies` (names captured from `Set-Cookie`), so the LLM can verify the chain stayed authenticated.
+
+### Revealing sensitive headers
+
+By default, sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`, `X-CSRF-Token`, `X-XSRF-Token`) are replaced with `[REDACTED]` in tool output to avoid leaking credentials into the model context. On an authorized engagement where you need the real values — to analyze or replay a captured authenticated request, or to produce a working `caido_export_curl` PoC — set `CAIDO_MCP_ALLOW_SENSITIVE` to a truthy value (`1`, `true`):
+
+```json
+{
+  "mcpServers": {
+    "caido": {
+      "command": "caido-mcp-server",
+      "args": ["serve"],
+      "env": {
+        "CAIDO_URL": "http://127.0.0.1:8080",
+        "CAIDO_MCP_ALLOW_SENSITIVE": "true"
+      }
+    }
+  }
+}
+```
+
+When enabled, real credential values flow through tool output to the model; leave it unset to keep redaction. This toggle does not affect the session cookie jar, which only ever reports cookie names and metadata, never values.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Both share the same auth token, the same Go SDK, and the same codebase.
 
 **Built-in security and performance:**
 
-- Credential redaction - Authorization, Cookie, and API key headers are redacted in tool output by default; opt out with `CAIDO_MCP_ALLOW_SENSITIVE` (see [Revealing sensitive headers](#revealing-sensitive-headers))
+- Credential redaction - Authorization, Cookie, and API key headers are redacted in tool output by default; opt out with `CAIDO_ALLOW_SENSITIVE_HEADERS` (see [Revealing sensitive headers](#revealing-sensitive-headers))
 - Session cookie jar - RFC 6265 jar per replay session; `Set-Cookie` from a response is auto-attached to the next `send_request` against the same session
 - Response fingerprinting - auto-detects content kind (json/html/xml/text/binary) so agents know what they're dealing with
 - Adaptive body limits - JSON gets 4KB, HTML 3KB, binary 200B (override with explicit `bodyLimit`)
@@ -67,7 +67,7 @@ The output of `caido_send_request` includes a `cookieJar` block with `injectedCo
 
 ### Revealing sensitive headers
 
-By default, sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`, `X-CSRF-Token`, `X-XSRF-Token`) are replaced with `[REDACTED]` in tool output to avoid leaking credentials into the model context. On an authorized engagement where you need the real values — to analyze or replay a captured authenticated request, or to produce a working `caido_export_curl` PoC — set `CAIDO_MCP_ALLOW_SENSITIVE` to a truthy value (`1`, `true`):
+By default, sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`, `X-CSRF-Token`, `X-XSRF-Token`) are replaced with `[REDACTED]` in tool output to avoid leaking credentials into the model context. On an authorized engagement where you need the real values — to analyze or replay a captured authenticated request, or to produce a working `caido_export_curl` PoC — set `CAIDO_ALLOW_SENSITIVE_HEADERS` to a truthy value (`1`, `true`):
 
 ```json
 {
@@ -77,7 +77,7 @@ By default, sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `Proxy-A
       "args": ["serve"],
       "env": {
         "CAIDO_URL": "http://127.0.0.1:8080",
-        "CAIDO_MCP_ALLOW_SENSITIVE": "true"
+        "CAIDO_ALLOW_SENSITIVE_HEADERS": "true"
       }
     }
   }

--- a/internal/httputil/parse.go
+++ b/internal/httputil/parse.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
+	"os"
+	"strconv"
 	"strings"
 )
 
@@ -21,6 +23,18 @@ var sensitiveHeaders = map[string]bool{
 	"x-auth-token":        true,
 	"x-csrf-token":        true,
 	"x-xsrf-token":        true,
+}
+
+// allowSensitiveHeaders reports whether sensitive-header redaction is disabled.
+// Opt in by setting CAIDO_MCP_ALLOW_SENSITIVE to a truthy value accepted by
+// strconv.ParseBool (1, t, T, TRUE, true, True); unset, empty, or unparseable
+// values keep the default redact-everything behavior. Read per ParseRaw call so
+// it stays testable and runtime-configurable. Intended for authorized
+// proxy/pentest work where replaying a captured authenticated request needs its
+// real Authorization/Cookie/CSRF headers.
+func allowSensitiveHeaders() bool {
+	allow, _ := strconv.ParseBool(os.Getenv("CAIDO_MCP_ALLOW_SENSITIVE"))
+	return allow
 }
 
 type Header struct {
@@ -68,6 +82,7 @@ func ParseRaw(
 	}
 
 	if includeHeaders {
+		allowSensitive := allowSensitiveHeaders()
 		reader := bufio.NewReader(bytes.NewReader(headerPart))
 		firstLine, err := reader.ReadString('\n')
 		if err == nil || err == io.EOF {
@@ -80,7 +95,7 @@ func ParseRaw(
 				if idx := strings.Index(line, ":"); idx > 0 {
 					name := strings.TrimSpace(line[:idx])
 					value := strings.TrimSpace(line[idx+1:])
-					if sensitiveHeaders[strings.ToLower(name)] {
+					if !allowSensitive && sensitiveHeaders[strings.ToLower(name)] {
 						value = "[REDACTED]"
 					}
 					result.Headers = append(result.Headers, Header{

--- a/internal/httputil/parse.go
+++ b/internal/httputil/parse.go
@@ -26,14 +26,14 @@ var sensitiveHeaders = map[string]bool{
 }
 
 // allowSensitiveHeaders reports whether sensitive-header redaction is disabled.
-// Opt in by setting CAIDO_MCP_ALLOW_SENSITIVE to a truthy value accepted by
+// Opt in by setting CAIDO_ALLOW_SENSITIVE_HEADERS to a truthy value accepted by
 // strconv.ParseBool (1, t, T, TRUE, true, True); unset, empty, or unparseable
 // values keep the default redact-everything behavior. Read per ParseRaw call so
 // it stays testable and runtime-configurable. Intended for authorized
 // proxy/pentest work where replaying a captured authenticated request needs its
 // real Authorization/Cookie/CSRF headers.
 func allowSensitiveHeaders() bool {
-	allow, _ := strconv.ParseBool(os.Getenv("CAIDO_MCP_ALLOW_SENSITIVE"))
+	allow, _ := strconv.ParseBool(os.Getenv("CAIDO_ALLOW_SENSITIVE_HEADERS"))
 	return allow
 }
 

--- a/internal/httputil/parse_test.go
+++ b/internal/httputil/parse_test.go
@@ -154,6 +154,66 @@ func TestParseRaw_SensitiveHeaderRedaction(t *testing.T) {
 	}
 }
 
+func TestParseRaw_SensitiveHeadersAllowedWhenOptedIn(t *testing.T) {
+	t.Setenv("CAIDO_MCP_ALLOW_SENSITIVE", "1")
+	raw := []byte(
+		"GET / HTTP/1.1\r\n" +
+			"Host: example.com\r\n" +
+			"Authorization: Bearer secret-token\r\n" +
+			"Cookie: session=abc123\r\n" +
+			"X-Api-Key: key-456\r\n" +
+			"Content-Type: text/html\r\n" +
+			"\r\n",
+	)
+	result := ParseRaw(raw, true, false, 0, 0)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	expects := map[string]string{
+		"Host":          "example.com",
+		"Authorization": "Bearer secret-token",
+		"Cookie":        "session=abc123",
+		"X-Api-Key":     "key-456",
+		"Content-Type":  "text/html",
+	}
+
+	for _, h := range result.Headers {
+		want, ok := expects[h.Name]
+		if !ok {
+			t.Fatalf("unexpected header: %s", h.Name)
+		}
+		if h.Value != want {
+			t.Fatalf(
+				"header %s: want %q, got %q",
+				h.Name, want, h.Value,
+			)
+		}
+	}
+}
+
+func TestParseRaw_SensitiveHeadersRedactedOnInvalidOptIn(t *testing.T) {
+	// An unparseable CAIDO_MCP_ALLOW_SENSITIVE must fail safe: keep redaction.
+	t.Setenv("CAIDO_MCP_ALLOW_SENSITIVE", "definitely-not-a-bool")
+	raw := []byte(
+		"GET / HTTP/1.1\r\n" +
+			"Authorization: Bearer secret-token\r\n" +
+			"\r\n",
+	)
+	result := ParseRaw(raw, true, false, 0, 0)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	for _, h := range result.Headers {
+		if h.Name == "Authorization" && h.Value != "[REDACTED]" {
+			t.Fatalf(
+				"Authorization: want %q, got %q",
+				"[REDACTED]", h.Value,
+			)
+		}
+	}
+}
+
 func TestParseRaw_FirstLine(t *testing.T) {
 	raw := []byte("POST /api HTTP/1.1\r\nHost: test.com\r\n\r\n")
 	result := ParseRaw(raw, true, false, 0, 0)

--- a/internal/httputil/parse_test.go
+++ b/internal/httputil/parse_test.go
@@ -155,7 +155,7 @@ func TestParseRaw_SensitiveHeaderRedaction(t *testing.T) {
 }
 
 func TestParseRaw_SensitiveHeadersAllowedWhenOptedIn(t *testing.T) {
-	t.Setenv("CAIDO_MCP_ALLOW_SENSITIVE", "1")
+	t.Setenv("CAIDO_ALLOW_SENSITIVE_HEADERS", "1")
 	raw := []byte(
 		"GET / HTTP/1.1\r\n" +
 			"Host: example.com\r\n" +
@@ -193,8 +193,8 @@ func TestParseRaw_SensitiveHeadersAllowedWhenOptedIn(t *testing.T) {
 }
 
 func TestParseRaw_SensitiveHeadersRedactedOnInvalidOptIn(t *testing.T) {
-	// An unparseable CAIDO_MCP_ALLOW_SENSITIVE must fail safe: keep redaction.
-	t.Setenv("CAIDO_MCP_ALLOW_SENSITIVE", "definitely-not-a-bool")
+	// An unparseable CAIDO_ALLOW_SENSITIVE_HEADERS must fail safe: keep redaction.
+	t.Setenv("CAIDO_ALLOW_SENSITIVE_HEADERS", "definitely-not-a-bool")
 	raw := []byte(
 		"GET / HTTP/1.1\r\n" +
 			"Authorization: Bearer secret-token\r\n" +


### PR DESCRIPTION
## Problem
If you're doing pentest style recon you can't analyze/replay/build a curl PoC from an authenticated request when its `Authorization`/`Cookie` reads `[REDACTED]`. In the case of an authorized engagement like a bug bounty program you would typically already hold those creds. This especially helps improve ergonomics with agentic testing.

This change allows a user to opt in to revealing them while keeping the safe default for everyone else.

## The Change
This PR adds an opt in `CAIDO_MCP_ALLOW_SENSITIVE` env var. When truthy (`strconv.ParseBool`: `1`, `true`, …), `ParseRaw` stops redacting sensitive headers (`Authorization`, `Cookie`, CSRF, API keys) so their real values reach tool output. 

Default (unset/invalid) keeps today's redact-everything behavior.

## Notes
- Gates redaction in `internal/httputil/parse.go` only; transitively un-redacts `caido_export_curl`. Does  not touch the session cookie jar (names/metadata only, never values).
- Read per `ParseRaw` call (testable); `strconv.ParseBool` means invalid values should fail safely
- Adds documentation udpates

## Naming Question
I chose `CAIDO_MCP_ALLOW_SENSITIVE` or match the `CAIDO_URL`/`CAIDO_PAT` style (e.g. `CAIDO_ALLOW_SENSITIVE_HEADERS` might align with the project better)? 

Please let me know and I'll update it asap!

---

Changelog entry if you want it: 
> **Opt in sensitive header reveal** -- `CAIDO_MCP_ALLOW_SENSITIVE` (truthy) disables redaction of `Authorization`/`Cookie`/CSRF/API-key headers in tool output, for analyzing/replaying/exporting authenticated requests on authorized engagements. Default unchanged & session cookie jar unaffected.