### PR TITLE
docs: finalize CHANGELOG for v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [4.2.1] - 2026-07-08
 
 ### Changed
 - Bump `modelcontextprotocol/go-sdk` v1.4.1 -> v1.6.1. Tool and input-validation errors now surface as spec-compliant MCP `isError` results instead of transport (Go) errors; server-side required-field enforcement is unchanged (still validated against the tool's input schema). No API changes to this server's tools.


### PR DESCRIPTION
Finalize the [Unreleased] go-sdk v1.6.1 entry as [4.2.1] ahead of tagging the release.