### PR TITLE
fix: send empty variables list when creating an environment

### DIFF
--- a/internal/tools/create_environment.go
+++ b/internal/tools/create_environment.go
@@ -35,8 +35,12 @@ func createEnvironmentHandler(
 			)
 		}
 
+		// The GraphQL schema requires a non-null variables list
+		// ([EnvironmentVariableInput!]!). A nil slice marshals to JSON null and
+		// the server rejects it, so send an empty (non-nil) slice.
 		resp, err := client.Environments.Create(ctx, &gen.CreateEnvironmentInput{
-			Name: input.Name,
+			Name:      input.Name,
+			Variables: []gen.EnvironmentVariableInput{},
 		})
 		if err != nil {
 			return nil, CreateEnvironmentOutput{}, err
@@ -45,10 +49,8 @@ func createEnvironmentHandler(
 		payload := resp.CreateEnvironment
 		if payload.Error != nil {
 			errType := "unknown"
-			if payload.Error != nil {
-				if tn := (*payload.Error).GetTypename(); tn != nil {
-					errType = *tn
-				}
+			if tn := (*payload.Error).GetTypename(); tn != nil {
+				errType = *tn
 			}
 			return nil, CreateEnvironmentOutput{}, fmt.Errorf(
 				"create environment failed: %s", errType,


### PR DESCRIPTION
`create_environment` fails every time it's called. The tool only takes a name, so it sends the GraphQL `Variables` field as a nil slice, which marshals to JSON `null`. Caido types that field as `[EnvironmentVariableInput!]!` (a non-null list), so the server rejects the `null` and no environment gets created.

## Change

- Pass an empty, non-nil `[]gen.EnvironmentVariableInput{}` for `Variables`. The environment is created with no variables, which is the expected result when the caller doesn't pass any.
- Minor cleanup: dropped a redundant nested `if payload.Error != nil` check in the same function (the outer block already guards it).

## Testing

- `go build ./...`, `go vet ./...` and `golangci-lint run ./...` clean.
- Rebuilt and ran `create_environment` against a live Caido 0.57.1 - the environment is created now. Before this change it failed with the schema error.
