### PR TITLE
fix: surface notable response headers in fingerprint, keep headers on body-dedup

### DIFF
--- a/internal/httputil/fingerprint.go
+++ b/internal/httputil/fingerprint.go
@@ -32,6 +32,14 @@ type Fingerprint struct {
 	RedirectTarget string   `json:"redirectTarget,omitempty"`
 	SetCookies     []string `json:"setCookies,omitempty"`
 	WordCount      int      `json:"wordCount,omitempty"`
+	// NotableHeaders surfaces response headers that are NOT part of the
+	// common standard/transport/caching/security set (see commonHeaders).
+	// This is where custom application signal hides -- framework banners
+	// (Server, X-Powered-By), debug/trace headers, internal hostnames, and
+	// CTF-style flag headers (X-Flag) -- which the other fingerprint fields
+	// never capture. Populated by PopulateResponseDetails from the same
+	// (already sensitive-redacted) header list the caller parsed.
+	NotableHeaders []Header `json:"notableHeaders,omitempty"`
 }
 
 func FingerprintFromHeaders(headers []Header, bodySize int) Fingerprint {
@@ -164,6 +172,52 @@ func WordCount(body []byte) int {
 	return len(strings.Fields(string(body)))
 }
 
+// commonHeaders are ordinary response headers that carry no per-app signal:
+// content negotiation, transport, caching, CORS, and standard security
+// headers. NotableHeaders excludes these so what remains is the unusual
+// stuff worth a human's attention. location and set-cookie are excluded
+// because they already have dedicated fingerprint fields (RedirectTarget,
+// SetCookies).
+var commonHeaders = map[string]bool{
+	"location": true, "set-cookie": true,
+	"content-type": true, "content-length": true, "content-encoding": true,
+	"content-language": true, "content-range": true, "content-disposition": true,
+	"date": true, "connection": true, "keep-alive": true, "transfer-encoding": true,
+	"vary": true, "accept-ranges": true, "age": true, "expires": true,
+	"cache-control": true, "pragma": true, "etag": true, "last-modified": true,
+	"access-control-allow-origin": true, "access-control-allow-credentials": true,
+	"access-control-allow-methods": true, "access-control-allow-headers": true,
+	"access-control-expose-headers": true, "access-control-max-age": true,
+	"strict-transport-security": true, "x-content-type-options": true,
+	"x-frame-options": true, "x-xss-protection": true, "content-security-policy": true,
+	"referrer-policy": true, "permissions-policy": true, "cross-origin-opener-policy": true,
+	"cross-origin-resource-policy": true, "cross-origin-embedder-policy": true,
+	"report-to": true, "nel": true, "alt-svc": true, "upgrade": true,
+}
+
+// maxNotableHeaders caps NotableHeaders so a pathological response cannot
+// bloat the tool output; the dropped count is not reported since the intent
+// is a summary, not an exhaustive dump (the full list stays in Headers).
+const maxNotableHeaders = 25
+
+// NotableHeaders returns the subset of headers whose names are not in
+// commonHeaders, preserving encounter order and stopping at
+// maxNotableHeaders. Always returns nil (not an empty slice) when nothing is
+// notable, so it stays omitempty in JSON output.
+func NotableHeaders(headers []Header) []Header {
+	var notable []Header
+	for _, h := range headers {
+		if commonHeaders[strings.ToLower(h.Name)] {
+			continue
+		}
+		notable = append(notable, h)
+		if len(notable) == maxNotableHeaders {
+			break
+		}
+	}
+	return notable
+}
+
 // SetCookieNames extracts cookie NAMES (never values) from a list of raw
 // Set-Cookie header values such as "session=abc123; Path=/". A value that
 // has already been redacted by ParseRaw's sensitive-header handling (i.e.
@@ -205,6 +259,7 @@ func PopulateResponseDetails(fp *Fingerprint, statusCode int, headers []Header, 
 	fp.StatusCode = statusCode
 	fp.RedirectTarget = headerValue(headers, "location")
 	fp.SetCookies = SetCookieNames(headerValues(headers, "set-cookie"))
+	fp.NotableHeaders = NotableHeaders(headers)
 	if fp.Kind == KindHTML {
 		fp.Title = ExtractTitle(body)
 	}

--- a/internal/httputil/fingerprint_test.go
+++ b/internal/httputil/fingerprint_test.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -276,6 +277,53 @@ func TestPopulateResponseDetails(t *testing.T) {
 		}
 		if fp.StatusCode != 200 {
 			t.Fatalf("want statusCode 200, got %d", fp.StatusCode)
+		}
+	})
+}
+
+func TestNotableHeaders(t *testing.T) {
+	t.Run("surfaces custom header, drops common ones", func(t *testing.T) {
+		headers := []Header{
+			{Name: "Content-Type", Value: "text/html"},
+			{Name: "Date", Value: "Mon, 01 Jan 2026 00:00:00 GMT"},
+			{Name: "Cache-Control", Value: "no-store"},
+			{Name: "X-Frame-Options", Value: "DENY"},
+			{Name: "Server", Value: "nginx"},
+			{Name: "X-Flag", Value: "flag{example}"},
+		}
+		got := NotableHeaders(headers)
+		if len(got) != 2 {
+			t.Fatalf("want 2 notable headers, got %d (%v)", len(got), got)
+		}
+		if got[0].Name != "Server" || got[1].Name != "X-Flag" {
+			t.Fatalf("want [Server X-Flag] in order, got %v", got)
+		}
+	})
+
+	t.Run("location and set-cookie excluded (dedicated fields)", func(t *testing.T) {
+		headers := []Header{
+			{Name: "Location", Value: "/dashboard"},
+			{Name: "Set-Cookie", Value: "session=abc"},
+		}
+		if got := NotableHeaders(headers); got != nil {
+			t.Fatalf("want nil, got %v", got)
+		}
+	})
+
+	t.Run("nothing notable returns nil", func(t *testing.T) {
+		headers := []Header{{Name: "Content-Type", Value: "application/json"}}
+		if got := NotableHeaders(headers); got != nil {
+			t.Fatalf("want nil for omitempty, got %v", got)
+		}
+	})
+
+	t.Run("caps at maxNotableHeaders", func(t *testing.T) {
+		headers := make([]Header, maxNotableHeaders+10)
+		for i := range headers {
+			headers[i] = Header{Name: "X-Custom-" + strconv.Itoa(i), Value: "v"}
+		}
+		if got := NotableHeaders(headers); len(got) != maxNotableHeaders {
+			t.Fatalf("want %d, got %d", maxNotableHeaders, len(got))
 		}
 	})
 }

--- a/internal/tools/send_request.go
+++ b/internal/tools/send_request.go
@@ -25,7 +25,7 @@ type SendRequestInput struct {
 	BodyLimit    int    `json:"bodyLimit,omitempty" jsonschema:"Response body byte limit (default 2000)"`
 	BodyOffset   int    `json:"bodyOffset,omitempty" jsonschema:"Response body byte offset (default 0)"`
 	UseCookieJar *bool  `json:"useCookieJar,omitempty" jsonschema:"Auto-inject session cookies and persist Set-Cookie (default true). Set false to disable for this call only."`
-	IncludeBody  *bool  `json:"includeBody,omitempty" jsonschema:"Include response body text in output (default true). The response fingerprint (title, redirect target, cookie names, word count) is always populated regardless of this setting."`
+	IncludeBody  *bool  `json:"includeBody,omitempty" jsonschema:"Include response body text in output (default true). The response fingerprint (title, redirect target, cookie names, word count, notable headers) is always populated regardless of this setting."`
 	Marker       string `json:"marker,omitempty" jsonschema:"Optional string to search for in the response body; when set, output.reflected reports whether it was found"`
 }
 
@@ -247,8 +247,13 @@ func sendRequestHandler(
 					if diff != nil {
 						output.Diff = diff
 						if diff.Same {
+							// The digest hashes status + body only, so "Same"
+							// proves the BODY repeated, not the headers. Clear
+							// the (large) body to save context, but keep headers
+							// -- a header can appear or change on a byte-identical
+							// body (X-Flag, rate-limit counters, tokens) and is
+							// exactly the signal a body-only dedup must not hide.
 							output.Response.Body = ""
-							output.Response.Headers = nil
 						}
 					}
 				}
@@ -287,7 +292,7 @@ func RegisterSendRequestTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_send_request",
-		Description: `Send HTTP request and return response inline. Returns statusCode, headers, body, and a response fingerprint (title, redirect target, cookie names, word count). Polls up to 10s for response. On timeout, returns entryId for follow-up via get_replay_entry. Session cookies (Set-Cookie) auto-persist between calls sharing the same sessionId; pass useCookieJar:false to disable for a single call. Set includeBody:false to omit body text (fingerprint stays populated); pass marker to check for reflection in the response body.`,
+		Description: `Send HTTP request and return response inline. Returns statusCode, headers, body, and a response fingerprint (title, redirect target, cookie names, word count, and notableHeaders -- non-standard response headers such as Server, X-Powered-By, or custom X-* headers where app/flag signal often hides; ALWAYS check these on every response, including 4xx/5xx). Polls up to 10s for response. On timeout, returns entryId for follow-up via get_replay_entry. Session cookies (Set-Cookie) auto-persist between calls sharing the same sessionId; pass useCookieJar:false to disable for a single call. Set includeBody:false to omit body text (fingerprint stays populated); pass marker to check for reflection in the response body.`,
 		Annotations: writeAnn(false, false, true),
 	}, sendRequestHandler(client))
 }


### PR DESCRIPTION
## Problem

Two mechanisms in `caido_send_request` hid response-header signal from the model:

1. The response `fingerprint` summarized `title`/`redirectTarget`/`setCookies`/`wordCount`/`statusCode` but never arbitrary headers. Custom headers (`Server`, `X-Powered-By`, `X-*` debug/flag headers) were present in the raw `headers` list but invisible in the summary.
2. The body-dedup path (`send_request.go`) nulled `Response.Headers` when a body repeated - but the dedup digest hashes only status + body (`diff.go:46`), never headers. A header that appears or changes on a byte-identical body got wiped on replay.

## Changes

- Add `Fingerprint.NotableHeaders`: response headers not in a curated `commonHeaders` set (content/transport/caching/CORS/standard-security), capped at 25, with `location`/`set-cookie` excluded since they have dedicated fields. Populated in `PopulateResponseDetails`, so it survives body-dedup.
- On `diff.Same`, clear only the body and keep headers.
- Tool description + `includeBody` schema mention `notableHeaders`.
- Table tests for `NotableHeaders`.

## Verification

- `go build ./...`, `go vet ./...`, `golangci-lint` clean
- `go test ./...` - 535 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)