### PR TITLE
fix: use HTTPQLInput type for filter GraphQL variables

### DIFF
--- a/internal/caido/client.go
+++ b/internal/caido/client.go
@@ -121,7 +121,7 @@ func (c *Client) ListRequests(ctx context.Context, opts ListRequestsOptions) (*L
 	}
 
 	if opts.Filter != "" {
-		req.Var("filter", opts.Filter)
+		req.Var("filter", map[string]string{"code": opts.Filter})
 	}
 
 	var resp ListRequestsResult
@@ -500,7 +500,7 @@ func (c *Client) ListFindings(ctx context.Context, opts ListFindingsOptions) (*L
 	}
 
 	if opts.Filter != "" {
-		req.Var("filter", opts.Filter)
+		req.Var("filter", map[string]string{"code": opts.Filter})
 	}
 
 	var resp ListFindingsResult

--- a/internal/caido/queries.go
+++ b/internal/caido/queries.go
@@ -3,7 +3,7 @@ package caido
 const (
 	// RequestsQuery is the GraphQL query for listing requests
 	RequestsQuery = `
-query Requests($first: Int, $after: String, $filter: HTTPQL) {
+query Requests($first: Int, $after: String, $filter: HTTPQLInput) {
   requests(first: $first, after: $after, filter: $filter) {
     edges {
       cursor
@@ -286,7 +286,7 @@ mutation CreateReplaySession($input: CreateReplaySessionInput!) {
 
 	// FindingsQuery lists all findings
 	FindingsQuery = `
-query Findings($first: Int, $after: String, $filter: HTTPQL) {
+query Findings($first: Int, $after: String, $filter: HTTPQLInput) {
   findings(first: $first, after: $after, filter: $filter) {
     edges {
       cursor


### PR DESCRIPTION
## Summary
- The `Requests` and `Findings` GraphQL queries declare their `$filter` variable as type `HTTPQL`, but the Caido backend schema defines `HTTPQL` as an `OBJECT` (output) type, not an input type.
- This makes any query using the variable invalid GraphQL, and breaks `list_requests`/`list_findings` filtering as well as initial token verification during `login` (fails with `Variable "filter" cannot be of non-input type "HTTPQL"`).
- The actual input type per the schema is `HTTPQLInput`, shaped as `{ code: String! }`.

## Fix
- Changed `$filter: HTTPQL` → `$filter: HTTPQLInput` in both queries (`internal/caido/queries.go`).
- Changed the filter variable value from a raw string to `map[string]string{"code": opts.Filter}` in both call sites (`internal/caido/client.go`).

## Test plan
- [x] Verified via GraphQL introspection against a live Caido instance that `HTTPQL` is `OBJECT` kind and `HTTPQLInput` is the correct `INPUT_OBJECT` (`{code: String!}`)
- [x] `go build` succeeds
- [x] `caido-mcp-server login` completes token verification successfully against a live Caido instance after the fix (previously failed with the GraphQL error above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)