### PR TITLE
docs: trim send/batch tool descriptions, move fingerprint fields to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **Static-token env var renamed to `CAIDO_ACCESS_TOKEN`.** This variable holds the local Caido app's GraphQL **access token** (from your login session), not a Caido Cloud Personal Access Token — the old `CAIDO_PAT` name was misleading. README now documents how to grab the access token from the Caido GUI.
+- **Trimmed `caido_send_request` / `caido_batch_send` tool descriptions** (~375 chars/call off every API call). The verbose response-fingerprint field reference now lives in the README "Response fingerprinting" section, pointed to from both descriptions. No behavior change.
 
 ### Deprecated
 - **`CAIDO_PAT` is deprecated** in favor of `CAIDO_ACCESS_TOKEN`. It still works as a fallback, but the MCP server now prints a deprecation warning to stderr when it is used. It will be removed in a future release. (Supersedes the `CAIDO_PAT` guidance in [1.4.0].)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ The `caido_send_request` tool maintains an in-memory `http.CookieJar` per replay
 
 The output of `caido_send_request` includes a `cookieJar` block with `injectedCookies` (names sent on this call) and `storedCookies` (names captured from `Set-Cookie`), so the LLM can verify the chain stayed authenticated.
 
+### Response fingerprinting
+
+Every `caido_send_request` / `caido_batch_send` response includes a compact fingerprint so an agent can reason about a response without the full body:
+
+- `title` - HTML `<title>`, if present
+- `redirect` - Location target on a 3xx
+- `cookieNames` - names set via `Set-Cookie` (values are never included)
+- `wordCount` - body word count, for size/diff comparison
+- `notableHeaders` - non-standard response headers (`Server`, `X-Powered-By`, custom `X-*`). App and flag signal often hides here - check these on every response, including 4xx/5xx.
+
+The fingerprint stays populated even when `includeBody: false`.
+
 ### Revealing sensitive headers
 
 By default, sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`, `X-CSRF-Token`, `X-XSRF-Token`) are replaced with `[REDACTED]` in tool output to avoid leaking credentials into the model context. On an authorized engagement where you need the real values — to analyze or replay a captured authenticated request, or to produce a working `caido_export_curl` PoC — set `CAIDO_ALLOW_SENSITIVE_HEADERS` to a truthy value (`1`, `true`):

--- a/internal/tools/batch_send.go
+++ b/internal/tools/batch_send.go
@@ -183,7 +183,7 @@ func RegisterBatchSendTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_batch_send",
-		Description: `Send multiple HTTP requests in parallel. Use for BAC token sweeps, parameter fuzzing, or endpoint sweeps. Max 50 per batch. Returns statusCode, headers, and a response fingerprint (title, redirect target, cookie names, word count) per request; body text is omitted by default to save tokens (set includeBody:true to include it). Pass marker to flag reflection per result. Set sessionId on each request to auto-inject session cookies and persist Set-Cookie across calls sharing the same ID.`,
+		Description: `Send multiple HTTP requests in parallel (max 50). Use for BAC token sweeps, parameter fuzzing, or endpoint sweeps. Returns statusCode, headers, and a response fingerprint per request; body text omitted by default (includeBody:true to include). marker flags reflection per result. Set sessionId per request to auto-inject and persist session cookies. See README "Response fingerprinting" for field details.`,
 		Annotations: writeAnn(false, false, true),
 	}, batchSendHandler(client))
 }

--- a/internal/tools/send_request.go
+++ b/internal/tools/send_request.go
@@ -292,7 +292,7 @@ func RegisterSendRequestTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_send_request",
-		Description: `Send HTTP request and return response inline. Returns statusCode, headers, body, and a response fingerprint (title, redirect target, cookie names, word count, and notableHeaders -- non-standard response headers such as Server, X-Powered-By, or custom X-* headers where app/flag signal often hides; ALWAYS check these on every response, including 4xx/5xx). Polls up to 10s for response. On timeout, returns entryId for follow-up via get_replay_entry. Session cookies (Set-Cookie) auto-persist between calls sharing the same sessionId; pass useCookieJar:false to disable for a single call. Set includeBody:false to omit body text (fingerprint stays populated); pass marker to check for reflection in the response body.`,
+		Description: `Send an HTTP request; returns statusCode, headers, body, and a response fingerprint (title, redirect, cookie names, word count, notableHeaders). Polls up to 10s; on timeout returns entryId for get_replay_entry. Session cookies auto-persist across calls with the same sessionId (useCookieJar:false to disable). includeBody:false omits body text; marker checks response body for reflection. See README "Response fingerprinting" for field details.`,
 		Annotations: writeAnn(false, false, true),
 	}, sendRequestHandler(client))
 }


### PR DESCRIPTION
## PR 1 — Trim send/batch descriptions → README (no behavior change)

Second in the staged MCP 2026-07-28 + tool-authoring series (follows #47).

Tool descriptions ship on every API call, so verbose ones cost context every turn. This moves
the response-fingerprint field list out of the `caido_send_request` / `caido_batch_send`
descriptions and into a new README **"Response fingerprinting"** section, referenced from both.

- ~375 chars saved per call.
- Descriptions keep every actionable fact (params, timeout/entryId behavior, cookie jar, marker).
- README now documents the fingerprint fields in more detail than the descriptions ever did.

### Changes
- `internal/tools/send_request.go`, `internal/tools/batch_send.go` — trimmed `Description`.
- `README.md` — new "Response fingerprinting" subsection.
- `CHANGELOG.md` — `Changed` bullet under `[Unreleased]`.

### Verification
- `go build ./...` clean; `go test ./...` all pass; `golangci-lint run` clean.
- No test pins the old description text.
