### PR TITLE
feat: add human-friendly Title to all MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **MCP 2026-07-28 protocol conformance test.** `TestProtocolVersionNegotiation` asserts the server negotiates protocol version `2026-07-28` (the go-sdk v1.7.0 default; the server pins no version), guarding against a future SDK downgrade or an accidental version pin. No behavior change.
+- **Human-friendly `title` on all 66 MCP tools.** The `2026-07-28` spec first-classes a display `title` distinct from the machine `name`; clients that render titles now show readable labels (e.g. `Send HTTP Request`, `List WebSocket Streams`). A `schema_test` guard enforces a non-empty title on every tool. Additive, no behavior change.
 
 ### Changed
 - **Static-token env var renamed to `CAIDO_ACCESS_TOKEN`.** This variable holds the local Caido app's GraphQL **access token** (from your login session), not a Caido Cloud Personal Access Token — the old `CAIDO_PAT` name was misleading. README now documents how to grab the access token from the Caido GUI.

--- a/internal/tools/automate_task_control.go
+++ b/internal/tools/automate_task_control.go
@@ -116,6 +116,7 @@ func RegisterAutomateTaskControlTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_automate_task_control",
+		Title:       "Control Automate Task",
 		Description: `Control fuzzing tasks. Actions: start (needs session_id), pause/resume/cancel (needs task_id).`,
 		Annotations: writeAnn(false, false, false),
 	}, automateTaskControlHandler(client))

--- a/internal/tools/batch_send.go
+++ b/internal/tools/batch_send.go
@@ -183,6 +183,7 @@ func RegisterBatchSendTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_batch_send",
+		Title:       "Batch Send Requests",
 		Description: `Send multiple HTTP requests in parallel (max 50). Use for BAC token sweeps, parameter fuzzing, or endpoint sweeps. Returns statusCode, headers, and a response fingerprint per request; body text omitted by default (includeBody:true to include). marker flags reflection per result. Set sessionId per request to auto-inject and persist session cookies. See README "Response fingerprinting" for field details.`,
 		Annotations: writeAnn(false, false, true),
 	}, batchSendHandler(client))

--- a/internal/tools/clear_session_cookies.go
+++ b/internal/tools/clear_session_cookies.go
@@ -57,6 +57,7 @@ func RegisterClearSessionCookiesTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_clear_session_cookies",
+		Title:       "Clear Session Cookies",
 		Description: `Wipe the in-memory cookie jar for a replay session. Use to force re-login flows or recover from poisoned cookie state. Returns sessionId and cleared status.`,
 		Annotations: writeAnn(false, true, false),
 	}, clearSessionCookiesHandler(client))

--- a/internal/tools/convert_body.go
+++ b/internal/tools/convert_body.go
@@ -67,7 +67,8 @@ func convertBodyHandler(
 // RegisterConvertBodyTool registers the tool with the MCP server.
 func RegisterConvertBodyTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_convert_body",
+		Name:  "caido_convert_body",
+		Title: "Convert Body",
 		Description: `Convert a request/response body between formats. ` +
 			`Formats: json, form (x-www-form-urlencoded), xml, multipart ` +
 			`(form-data). Params: body, from, to. ` +

--- a/internal/tools/create_environment.go
+++ b/internal/tools/create_environment.go
@@ -72,6 +72,7 @@ func createEnvironmentHandler(
 func RegisterCreateEnvironmentTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_create_environment",
+		Title:       "Create Environment",
 		Description: `Create a new environment. Environments store variables (tokens, keys, etc) that can be used in replay placeholders.`,
 		Annotations: writeAnn(false, false, false),
 	}, createEnvironmentHandler(client))

--- a/internal/tools/create_filter.go
+++ b/internal/tools/create_filter.go
@@ -77,7 +77,8 @@ func RegisterCreateFilterTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_create_filter",
+		Name:  "caido_create_filter",
+		Title: "Create Filter",
 		Description: `Create a new HTTPQL filter preset. ` +
 			`Returns id/name/alias of the created filter.`,
 		Annotations: writeAnn(false, false, false),

--- a/internal/tools/create_finding.go
+++ b/internal/tools/create_finding.go
@@ -98,6 +98,7 @@ func RegisterCreateFindingTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_create_finding",
+		Title:       "Create Finding",
 		Description: `Create finding. Params: requestId, title, description (optional).`,
 		Annotations: writeAnn(false, false, false),
 	}, createFindingHandler(client))

--- a/internal/tools/create_project.go
+++ b/internal/tools/create_project.go
@@ -58,6 +58,7 @@ func RegisterCreateProjectTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_create_project",
+		Title:       "Create Project",
 		Description: `Create a new project with the specified name.`,
 		Annotations: writeAnn(false, false, false),
 	}, createProjectHandler(client))

--- a/internal/tools/create_replay_collection.go
+++ b/internal/tools/create_replay_collection.go
@@ -54,6 +54,7 @@ func RegisterCreateReplayCollectionTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_create_replay_collection",
+		Title:       "Create Replay Collection",
 		Description: `Create a named replay collection to organize replay sessions.`,
 		Annotations: writeAnn(false, false, false),
 	}, createReplayCollectionHandler(client))

--- a/internal/tools/create_replay_session.go
+++ b/internal/tools/create_replay_session.go
@@ -80,6 +80,7 @@ func RegisterCreateReplaySessionTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_create_replay_session",
+		Title:       "Create Replay Session",
 		Description: `Create a named replay session. Optionally seed it with an existing request and assign to a collection. Use this to organize replay work by target or task.`,
 		Annotations: writeAnn(false, false, false),
 	}, createReplaySessionHandler(client))

--- a/internal/tools/create_scope.go
+++ b/internal/tools/create_scope.go
@@ -90,7 +90,8 @@ func createScopeHandler(
 // RegisterCreateScopeTool registers the tool with the MCP server
 func RegisterCreateScopeTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_create_scope",
+		Name:  "caido_create_scope",
+		Title: "Create Scope",
 		Description: `Create scope. Params: name, allowlist, denylist. ` +
 			`Values are hostnames, not URLs. ` +
 			`Examples: "example.com", "*.example.com". ` +

--- a/internal/tools/create_tamper_rule.go
+++ b/internal/tools/create_tamper_rule.go
@@ -229,7 +229,8 @@ func RegisterCreateTamperRuleTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_create_tamper_rule",
+		Name:  "caido_create_tamper_rule",
+		Title: "Create Tamper Rule",
 		Description: `Create a Match & Replace (tamper) rule. ` +
 			`Params: collection_id (required), name (required), ` +
 			`section (required: requestAll/requestHeader/requestBody/` +

--- a/internal/tools/delete_environment.go
+++ b/internal/tools/delete_environment.go
@@ -61,6 +61,7 @@ func deleteEnvironmentHandler(
 func RegisterDeleteEnvironmentTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_delete_environment",
+		Title:       "Delete Environment",
 		Description: `Delete an environment by ID. Note: the Global environment cannot be deleted.`,
 		Annotations: writeAnn(true, true, false),
 	}, deleteEnvironmentHandler(client))

--- a/internal/tools/delete_filter.go
+++ b/internal/tools/delete_filter.go
@@ -48,7 +48,8 @@ func RegisterDeleteFilterTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_delete_filter",
+		Name:  "caido_delete_filter",
+		Title: "Delete Filter",
 		Description: `Delete a filter preset by ID. ` +
 			`Returns success status.`,
 		Annotations: writeAnn(true, true, false),

--- a/internal/tools/delete_findings.go
+++ b/internal/tools/delete_findings.go
@@ -112,6 +112,7 @@ func RegisterDeleteFindingsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_delete_findings",
+		Title:       "Delete Findings",
 		Description: `Delete findings by IDs or by reporter name. Params: ids (list) or reporter (string).`,
 		Annotations: writeAnn(true, true, false),
 	}, deleteFindingsHandler(client))

--- a/internal/tools/delete_project.go
+++ b/internal/tools/delete_project.go
@@ -46,6 +46,7 @@ func RegisterDeleteProjectTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_delete_project",
+		Title:       "Delete Project",
 		Description: `Delete a project by ID. This operation cannot be undone.`,
 		Annotations: writeAnn(true, true, false),
 	}, deleteProjectHandler(client))

--- a/internal/tools/delete_replay_collection.go
+++ b/internal/tools/delete_replay_collection.go
@@ -38,6 +38,7 @@ func RegisterDeleteReplayCollectionTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_delete_replay_collection",
+		Title:       "Delete Replay Collection",
 		Description: `Delete a replay collection. Sessions in the collection will not be deleted.`,
 		Annotations: writeAnn(true, true, false),
 	}, deleteReplayCollectionHandler(client))

--- a/internal/tools/delete_replay_sessions.go
+++ b/internal/tools/delete_replay_sessions.go
@@ -44,6 +44,7 @@ func RegisterDeleteReplaySessionsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_delete_replay_sessions",
+		Title:       "Delete Replay Sessions",
 		Description: `Delete one or more replay sessions by ID.`,
 		Annotations: writeAnn(true, true, false),
 	}, deleteReplaySessionsHandler(client))

--- a/internal/tools/delete_scope.go
+++ b/internal/tools/delete_scope.go
@@ -44,6 +44,7 @@ func deleteScopeHandler(
 func RegisterDeleteScopeTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_delete_scope",
+		Title:       "Delete Scope",
 		Description: `Delete a scope by ID.`,
 		Annotations: writeAnn(true, true, false),
 	}, deleteScopeHandler(client))

--- a/internal/tools/delete_tamper_rule.go
+++ b/internal/tools/delete_tamper_rule.go
@@ -50,7 +50,8 @@ func RegisterDeleteTamperRuleTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_delete_tamper_rule",
+		Name:  "caido_delete_tamper_rule",
+		Title: "Delete Tamper Rule",
 		Description: `Delete a Match & Replace (tamper) rule ` +
 			`by ID. Params: id (required).`,
 		Annotations: writeAnn(true, true, false),

--- a/internal/tools/diff_responses.go
+++ b/internal/tools/diff_responses.go
@@ -208,6 +208,7 @@ func RegisterDiffResponsesTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_diff_responses",
+		Title:       "Diff Responses",
 		Description: `Compare two responses by Caido request ID (idA, idB). Returns status/size change flags and a compact body/header diff summary. Does not dump full bodies.`,
 		Annotations: readOnlyAnn(),
 	}, diffResponsesHandler(client))

--- a/internal/tools/drop_intercept.go
+++ b/internal/tools/drop_intercept.go
@@ -54,6 +54,7 @@ func RegisterDropInterceptTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_drop_intercept",
+		Title:       "Drop Intercepted Request",
 		Description: `Drop intercepted request (do not forward to server). The client receives no response.`,
 		Annotations: writeAnn(true, true, false),
 	}, dropInterceptHandler(client))

--- a/internal/tools/edit_request.go
+++ b/internal/tools/edit_request.go
@@ -273,6 +273,7 @@ func RegisterEditRequestTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_edit_request",
+		Title:       "Edit Request",
 		Description: `Modify and resend an existing request. Fetches original request, applies modifications (method, path, headers, body), preserves auth/cookies, and sends the modified request. Returns same output as send_request.`,
 		Annotations: writeAnn(false, false, true),
 	}, editRequestHandler(client))

--- a/internal/tools/export_curl.go
+++ b/internal/tools/export_curl.go
@@ -124,6 +124,7 @@ func RegisterExportCurlTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_export_curl",
+		Title:       "Export as curl",
 		Description: `Convert a Caido request to a curl command. Returns executable curl command string with method, URL, headers, and body.`,
 		Annotations: readOnlyAnn(),
 	}, exportCurlHandler(client))

--- a/internal/tools/export_findings.go
+++ b/internal/tools/export_findings.go
@@ -144,6 +144,7 @@ func RegisterExportFindingsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_export_findings",
+		Title:       "Export Findings",
 		Description: `Export findings. Filter by IDs or reporter name. Returns exportId for download.`,
 		Annotations: readOnlyAnn(),
 	}, exportFindingsHandler(client))

--- a/internal/tools/forward_intercept.go
+++ b/internal/tools/forward_intercept.go
@@ -71,6 +71,7 @@ func RegisterForwardInterceptTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_forward_intercept",
+		Title:       "Forward Intercepted Request",
 		Description: `Forward intercepted request. Optionally modify with base64-encoded raw HTTP request. Params: id (required), raw (optional).`,
 		Annotations: writeAnn(false, false, true),
 	}, forwardInterceptHandler(client))

--- a/internal/tools/get_automate_entry.go
+++ b/internal/tools/get_automate_entry.go
@@ -149,6 +149,7 @@ func RegisterGetAutomateEntryTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_get_automate_entry",
+		Title:       "Get Automate Entry",
 		Description: `Get fuzz results. Returns sequenceId/payloads/requestId/statusCode. Use limit/after for pagination.`,
 		Annotations: readOnlyAnn(),
 	}, getAutomateEntryHandler(client))

--- a/internal/tools/get_automate_session.go
+++ b/internal/tools/get_automate_session.go
@@ -103,6 +103,7 @@ func RegisterGetAutomateSessionTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_get_automate_session",
+		Title:       "Get Automate Session",
 		Description: `Get fuzzing session details. Returns requestTemplate and list of entry IDs.`,
 		Annotations: readOnlyAnn(),
 	}, getAutomateSessionHandler(client))

--- a/internal/tools/get_instance.go
+++ b/internal/tools/get_instance.go
@@ -43,7 +43,8 @@ func RegisterGetInstanceTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_get_instance",
+		Name:  "caido_get_instance",
+		Title: "Get Instance Info",
 		Description: `Get Caido instance info. ` +
 			`Returns version and platform.`,
 		Annotations: readOnlyAnn(),

--- a/internal/tools/get_replay_entry.go
+++ b/internal/tools/get_replay_entry.go
@@ -95,6 +95,7 @@ func RegisterGetReplayEntryTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_get_replay_entry",
+		Title:       "Get Replay Entry",
 		Description: `Get replay entry with full request and response content. Use after send_request timeout to retrieve results.`,
 		Annotations: readOnlyAnn(),
 	}, getReplayEntryHandler(client))

--- a/internal/tools/get_request.go
+++ b/internal/tools/get_request.go
@@ -213,6 +213,7 @@ func RegisterGetRequestTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_get_request",
+		Title:       "Get Request",
 		Description: `Get request details. Default: metadata only (saves tokens). Use include=[requestHeaders,requestBody,responseHeaders,responseBody] for more. Body limit: 2KB default.`,
 		Annotations: readOnlyAnn(),
 	}, getRequestHandler(client))

--- a/internal/tools/get_session_cookies.go
+++ b/internal/tools/get_session_cookies.go
@@ -97,6 +97,7 @@ func RegisterGetSessionCookiesTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_get_session_cookies",
+		Title:       "Get Session Cookies",
 		Description: `List cookies stored in the session jar that match a URL (RFC 6265). Returns metadata only (name/length/domain/path/flags); values are not exposed to avoid leaking tokens into model context. Use to debug cookie persistence between send_request calls.`,
 		Annotations: readOnlyAnn(),
 	}, getSessionCookiesHandler(client))

--- a/internal/tools/get_sitemap.go
+++ b/internal/tools/get_sitemap.go
@@ -96,6 +96,7 @@ func RegisterGetSitemapTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_get_sitemap",
+		Title:       "Get Sitemap",
 		Description: `Get sitemap. No params=root domains. parentId=children. Returns id/label/kind.`,
 		Annotations: readOnlyAnn(),
 	}, getSitemapHandler(client))

--- a/internal/tools/intercept_control.go
+++ b/internal/tools/intercept_control.go
@@ -63,6 +63,7 @@ func RegisterInterceptControlTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_intercept_control",
+		Title:       "Control Intercept",
 		Description: `Pause or resume the intercept proxy. Pausing lets requests flow through unmodified.`,
 		Annotations: writeAnn(false, false, false),
 	}, interceptControlHandler(client))

--- a/internal/tools/intercept_status.go
+++ b/internal/tools/intercept_status.go
@@ -41,6 +41,7 @@ func RegisterInterceptStatusTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_intercept_status",
+		Title:       "Get Intercept Status",
 		Description: `Get intercept status (PAUSED or RUNNING).`,
 		Annotations: readOnlyAnn(),
 	}, interceptStatusHandler(client))

--- a/internal/tools/is_in_scope.go
+++ b/internal/tools/is_in_scope.go
@@ -191,7 +191,8 @@ func isInScopeHandler(
 // RegisterIsInScopeTool registers the tool with the MCP server
 func RegisterIsInScopeTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_is_in_scope",
+		Name:  "caido_is_in_scope",
+		Title: "Check In Scope",
 		Description: `Check whether a host or URL is in the project scope. ` +
 			`Accepts a bare host ("example.com") or a full URL ` +
 			`("https://example.com/path"); the port and path are ignored. ` +

--- a/internal/tools/list_automate_sessions.go
+++ b/internal/tools/list_automate_sessions.go
@@ -67,6 +67,7 @@ func RegisterListAutomateSessionsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_automate_sessions",
+		Title:       "List Automate Sessions",
 		Description: `List fuzzing sessions. Returns id/name/createdAt.`,
 		InputSchema: map[string]any{"type": "object"},
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_environments.go
+++ b/internal/tools/list_environments.go
@@ -97,6 +97,7 @@ func RegisterListEnvironmentsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_environments",
+		Title:       "List Environments",
 		Description: `List environments and their variables (tokens, keys, etc). Shows which is currently selected.`,
 		Annotations: readOnlyAnn(),
 	}, listEnvironmentsHandler(client))

--- a/internal/tools/list_filters.go
+++ b/internal/tools/list_filters.go
@@ -78,7 +78,8 @@ func RegisterListFiltersTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_list_filters",
+		Name:  "caido_list_filters",
+		Title: "List Filters",
 		Description: `List saved HTTPQL filter presets. ` +
 			`Returns id/name/alias/clause.`,
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_findings.go
+++ b/internal/tools/list_findings.go
@@ -101,6 +101,7 @@ func RegisterListFindingsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_findings",
+		Title:       "List Findings",
 		Description: `List security findings. Returns title/host/path/requestId.`,
 		Annotations: readOnlyAnn(),
 	}, listFindingsHandler(client))

--- a/internal/tools/list_hosted_files.go
+++ b/internal/tools/list_hosted_files.go
@@ -54,6 +54,7 @@ func listHostedFilesHandler(
 func RegisterListHostedFilesTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_hosted_files",
+		Title:       "List Hosted Files",
 		Description: `List hosted files available in Caido for serving payloads.`,
 		InputSchema: map[string]any{"type": "object"},
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_intercept_entries.go
+++ b/internal/tools/list_intercept_entries.go
@@ -111,6 +111,7 @@ func RegisterListInterceptEntriesTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_intercept_entries",
+		Title:       "List Intercept Entries",
 		Description: `List queued intercept entries. Filter with httpql. Returns id/method/url/status. Use with forward/drop tools.`,
 		Annotations: readOnlyAnn(),
 	}, listInterceptEntriesHandler(client))

--- a/internal/tools/list_plugins.go
+++ b/internal/tools/list_plugins.go
@@ -52,6 +52,7 @@ func listPluginsHandler(
 func RegisterListPluginsTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_plugins",
+		Title:       "List Plugins",
 		Description: `List installed Caido plugins with version info.`,
 		InputSchema: map[string]any{"type": "object"},
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_projects.go
+++ b/internal/tools/list_projects.go
@@ -76,7 +76,8 @@ func RegisterListProjectsTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_list_projects",
+		Name:  "caido_list_projects",
+		Title: "List Projects",
 		Description: `List projects. Returns id/name/status/version. ` +
 			`Current project marked with isCurrent.`,
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_replay_collections.go
+++ b/internal/tools/list_replay_collections.go
@@ -55,6 +55,7 @@ func RegisterListReplayCollectionsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_replay_collections",
+		Title:       "List Replay Collections",
 		Description: `List replay collections. Returns id and name for each collection.`,
 		InputSchema: map[string]any{"type": "object"},
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_replay_sessions.go
+++ b/internal/tools/list_replay_sessions.go
@@ -59,6 +59,7 @@ func RegisterListReplaySessionsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_replay_sessions",
+		Title:       "List Replay Sessions",
 		Description: `List replay sessions. Returns id and name for each session.`,
 		InputSchema: map[string]any{"type": "object"},
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_requests.go
+++ b/internal/tools/list_requests.go
@@ -99,6 +99,7 @@ func RegisterListRequestsTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_requests",
+		Title:       "List Requests",
 		Description: `List HTTP requests. Filter with httpql (e.g. req.host.eq:"example.com"). Returns id/method/url/status.`,
 		Annotations: readOnlyAnn(),
 	}, listRequestsHandler(client))

--- a/internal/tools/list_scopes.go
+++ b/internal/tools/list_scopes.go
@@ -60,6 +60,7 @@ func listScopesHandler(
 func RegisterListScopesTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_scopes",
+		Title:       "List Scopes",
 		Description: `List scopes. Returns name/allowlist/denylist.`,
 		InputSchema: map[string]any{"type": "object"},
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_tamper_rules.go
+++ b/internal/tools/list_tamper_rules.go
@@ -111,7 +111,8 @@ func RegisterListTamperRulesTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_list_tamper_rules",
+		Name:  "caido_list_tamper_rules",
+		Title: "List Tamper Rules",
 		Description: `List Match & Replace (tamper) rule ` +
 			`collections and their rules. Returns ` +
 			`collection id/name with nested rules ` +

--- a/internal/tools/list_workflows.go
+++ b/internal/tools/list_workflows.go
@@ -64,7 +64,8 @@ func RegisterListWorkflowsTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_list_workflows",
+		Name:  "caido_list_workflows",
+		Title: "List Workflows",
 		Description: `List automation workflows. ` +
 			`Returns id/name/kind/enabled.`,
 		Annotations: readOnlyAnn(),

--- a/internal/tools/list_ws_messages.go
+++ b/internal/tools/list_ws_messages.go
@@ -115,7 +115,8 @@ func decodeWsBody(raw string, limit int) (string, bool) {
 // RegisterListWsMessagesTool registers the tool with the MCP server
 func RegisterListWsMessagesTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_list_ws_messages",
+		Name:  "caido_list_ws_messages",
+		Title: "List WebSocket Messages",
 		Description: `List WebSocket frames for a stream (from caido_list_ws_streams). ` +
 			`Each frame has direction (CLIENT/SERVER), format (TEXT/BINARY), ` +
 			`length, and decoded body (truncated to body_limit). ` +

--- a/internal/tools/list_ws_streams.go
+++ b/internal/tools/list_ws_streams.go
@@ -95,7 +95,8 @@ func listWsStreamsHandler(
 // RegisterListWsStreamsTool registers the tool with the MCP server
 func RegisterListWsStreamsTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_list_ws_streams",
+		Name:  "caido_list_ws_streams",
+		Title: "List WebSocket Streams",
 		Description: `List WebSocket streams (connections) from the WebSocket tab. ` +
 			`Returns id/host/port/path/direction/source. ` +
 			`Use the stream id with caido_list_ws_messages to read frames. ` +

--- a/internal/tools/move_replay_session.go
+++ b/internal/tools/move_replay_session.go
@@ -50,6 +50,7 @@ func RegisterMoveReplaySessionTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_move_replay_session",
+		Title:       "Move Replay Session",
 		Description: `Move a replay session to a different collection.`,
 		Annotations: writeAnn(false, true, false),
 	}, moveReplaySessionHandler(client))

--- a/internal/tools/race_window_send.go
+++ b/internal/tools/race_window_send.go
@@ -131,6 +131,7 @@ func RegisterRaceWindowSendTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_race_window_send",
+		Title:       "Race-Window Send",
 		Description: `Fire multiple raw HTTP/1.1 requests with a synchronized last-byte send (single-packet / race-window style) for race-condition testing. All connections are dialed and parked at a barrier; final bytes are written together after the barrier opens (best-effort simultaneity, not guaranteed sub-ms). WARNING: this BYPASSES the Caido proxy -- requests are sent via raw sockets from this process and do NOT appear in Caido history. Max 50 requests.`,
 		Annotations: writeAnn(false, false, true),
 	}, raceWindowSendHandler(client))

--- a/internal/tools/rename_project.go
+++ b/internal/tools/rename_project.go
@@ -59,6 +59,7 @@ func RegisterRenameProjectTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_rename_project",
+		Title:       "Rename Project",
 		Description: `Rename an existing project.`,
 		Annotations: writeAnn(false, true, false),
 	}, renameProjectHandler(client))

--- a/internal/tools/rename_replay_collection.go
+++ b/internal/tools/rename_replay_collection.go
@@ -50,6 +50,7 @@ func RegisterRenameReplayCollectionTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_rename_replay_collection",
+		Title:       "Rename Replay Collection",
 		Description: `Rename a replay collection.`,
 		Annotations: writeAnn(false, true, false),
 	}, renameReplayCollectionHandler(client))

--- a/internal/tools/rename_scope.go
+++ b/internal/tools/rename_scope.go
@@ -49,6 +49,7 @@ func renameScopeHandler(
 func RegisterRenameScopeTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_rename_scope",
+		Title:       "Rename Scope",
 		Description: `Rename a scope by ID.`,
 		Annotations: writeAnn(false, true, false),
 	}, renameScopeHandler(client))

--- a/internal/tools/run_workflow.go
+++ b/internal/tools/run_workflow.go
@@ -139,7 +139,8 @@ func RegisterRunWorkflowTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_run_workflow",
+		Name:  "caido_run_workflow",
+		Title: "Run Workflow",
 		Description: `Execute a workflow. Params: id (required), ` +
 			`type (active/convert), request_id (for active), ` +
 			`input (for convert). Active workflows run on a ` +

--- a/internal/tools/schema_test.go
+++ b/internal/tools/schema_test.go
@@ -24,6 +24,9 @@ func TestAllToolsRegisterWithoutPanic(t *testing.T) {
 		if tool.Description == "" {
 			t.Errorf("tool %q has empty description", tool.Name)
 		}
+		if tool.Title == "" {
+			t.Errorf("tool %q has empty title", tool.Name)
+		}
 		if tool.InputSchema == nil {
 			t.Errorf("tool %q has nil InputSchema", tool.Name)
 		}

--- a/internal/tools/select_environment.go
+++ b/internal/tools/select_environment.go
@@ -76,6 +76,7 @@ func RegisterSelectEnvironmentTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_select_environment",
+		Title:       "Select Environment",
 		Description: `Select active environment. Variables from selected env are used in replay placeholders. Pass empty id to deselect. Note: the Global environment (usually id "1") is always active and cannot be selected via this API.`,
 		Annotations: writeAnn(false, true, false),
 	}, selectEnvironmentHandler(client))

--- a/internal/tools/select_project.go
+++ b/internal/tools/select_project.go
@@ -60,6 +60,7 @@ func RegisterSelectProjectTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_select_project",
+		Title:       "Select Project",
 		Description: `Switch active project. All subsequent operations use the selected project's data.`,
 		Annotations: writeAnn(false, true, false),
 	}, selectProjectHandler(client))

--- a/internal/tools/send_request.go
+++ b/internal/tools/send_request.go
@@ -292,6 +292,7 @@ func RegisterSendRequestTool(
 ) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_send_request",
+		Title:       "Send HTTP Request",
 		Description: `Send an HTTP request; returns statusCode, headers, body, and a response fingerprint (title, redirect, cookie names, word count, notableHeaders). Polls up to 10s; on timeout returns entryId for get_replay_entry. Session cookies auto-persist across calls with the same sessionId (useCookieJar:false to disable). includeBody:false omits body text; marker checks response body for reflection. See README "Response fingerprinting" for field details.`,
 		Annotations: writeAnn(false, false, true),
 	}, sendRequestHandler(client))

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -53,6 +53,7 @@ func listTasksHandler(
 func RegisterListTasksTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_list_tasks",
+		Title:       "List Tasks",
 		Description: `List running background tasks (replay, workflow, export).`,
 		InputSchema: map[string]any{"type": "object"},
 		Annotations: readOnlyAnn(),
@@ -92,6 +93,7 @@ func cancelTaskHandler(
 func RegisterCancelTaskTool(server *mcp.Server, client *caido.Client) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "caido_cancel_task",
+		Title:       "Cancel Task",
 		Description: `Cancel a running background task by ID.`,
 		Annotations: writeAnn(false, true, false),
 	}, cancelTaskHandler(client))

--- a/internal/tools/toggle_tamper_rule.go
+++ b/internal/tools/toggle_tamper_rule.go
@@ -69,7 +69,8 @@ func RegisterToggleTamperRuleTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_toggle_tamper_rule",
+		Name:  "caido_toggle_tamper_rule",
+		Title: "Toggle Tamper Rule",
 		Description: `Enable or disable a Match & Replace ` +
 			`(tamper) rule. Params: id (required), ` +
 			`enabled (true/false).`,

--- a/internal/tools/toggle_workflow.go
+++ b/internal/tools/toggle_workflow.go
@@ -69,7 +69,8 @@ func RegisterToggleWorkflowTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_toggle_workflow",
+		Name:  "caido_toggle_workflow",
+		Title: "Toggle Workflow",
 		Description: `Enable or disable an automation workflow. ` +
 			`Params: id (required), enabled (true/false).`,
 		Annotations: writeAnn(false, false, false),

--- a/internal/tools/update_tamper_rule.go
+++ b/internal/tools/update_tamper_rule.go
@@ -152,7 +152,8 @@ func RegisterUpdateTamperRuleTool(
 	server *mcp.Server, client *caido.Client,
 ) {
 	mcp.AddTool(server, &mcp.Tool{
-		Name: "caido_update_tamper_rule",
+		Name:  "caido_update_tamper_rule",
+		Title: "Update Tamper Rule",
 		Description: `Update an existing Match & Replace ` +
 			`(tamper) rule. Params: id (required), ` +
 			`name (required), section (required: requestAll/` +


### PR DESCRIPTION
## PR 2 — Human-friendly `title` on all 66 tools (additive, no behavior change)

Third in the staged MCP 2026-07-28 + tool-authoring series (follows #47, #48).

The `2026-07-28` spec first-classes a display `title` distinct from the machine `name`. This
adds a readable `Title` to every tool so clients that render titles show friendly labels
instead of `caido_snake_case`. A `schema_test` guard now enforces a non-empty title on every
tool, so new tools can't skip it.

### Titles

| Tool | Title |
|------|-------|
| send_request | Send HTTP Request |
| batch_send | Batch Send Requests |
| edit_request | Edit Request |
| race_window_send | Race-Window Send |
| get_request / get_sitemap | Get Request / Get Sitemap |
| list_requests | List Requests |
| diff_responses | Diff Responses |
| export_curl | Export as curl |
| list_ws_streams / list_ws_messages | List WebSocket Streams / Messages |
| create/delete/rename/select_project | Create/Delete/Rename/Select Project |
| create/delete/rename_scope, is_in_scope, list_scopes | …Scope / Check In Scope / List Scopes |
| create/delete/list/export findings, create_finding | …Findings |
| *_replay_session(s) / *_replay_collection | Create/Delete/Move/Rename Replay … |
| *_tamper_rule (create/update/toggle/delete/list) | …Tamper Rule |
| *_environment, *_filter, *_workflow | Create/Delete/List/Select/Run/Toggle … |
| intercept_status/control, forward/drop_intercept, list_intercept_entries | Get/Control/Forward/Drop/List Intercept … |
| *_session_cookies (get/clear), get_session/entry, automate_* | Session Cookies / Automate … |
| list_tasks / cancel_task | List Tasks / Cancel Task |
| get_instance / list_plugins / list_hosted_files / convert_body | Get Instance Info / … |

(Full list in the diff; acronyms expanded — `WS`→`WebSocket`.)

### Changes
- 66 tool files: added `Title` to each `mcp.Tool` literal (gofmt-aligned).
- `internal/tools/schema_test.go`: assert every listed tool has a non-empty `Title`.
- `CHANGELOG.md`: `Added` bullet under `[Unreleased]`.

### Verification
- `go build ./...` clean; `go test ./...` all pass (incl. the new title guard); `golangci-lint run` clean; `gofmt -l` clean.
- Sanity-checked the diff: only `Title` additions + field realignment, no content changes.
