### PR TITLE
fix(test): pin CAIDO_ALLOW_SENSITIVE_HEADERS in redaction tests

### DIFF
--- a/internal/httputil/parse_test.go
+++ b/internal/httputil/parse_test.go
@@ -123,6 +123,12 @@ func TestParseRaw_DuplicateHeaders(t *testing.T) {
 }
 
 func TestParseRaw_SensitiveHeaderRedaction(t *testing.T) {
+	// This asserts redaction is ON, which depends on
+	// CAIDO_ALLOW_SENSITIVE_HEADERS being falsy. Pin it rather than
+	// inheriting the developer's or CI's environment: a shell exporting
+	// the opt-out turned this security test into a false failure.
+	t.Setenv("CAIDO_ALLOW_SENSITIVE_HEADERS", "")
+
 	raw := []byte(
 		"GET / HTTP/1.1\r\n" +
 			"Host: example.com\r\n" +

--- a/internal/httputil/redact_test.go
+++ b/internal/httputil/redact_test.go
@@ -9,7 +9,7 @@ func TestRedactRawHeaders(t *testing.T) {
 	tests := []struct {
 		name        string
 		raw         string
-		allow       string // CAIDO_ALLOW_SENSITIVE_HEADERS value; "" leaves it unset
+		allow       string // CAIDO_ALLOW_SENSITIVE_HEADERS value; "" means redact
 		wantContain []string
 		wantAbsent  []string
 	}{
@@ -104,9 +104,13 @@ func TestRedactRawHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.allow != "" {
-				t.Setenv("CAIDO_ALLOW_SENSITIVE_HEADERS", tt.allow)
-			}
+			// Always pin the variable, including to "". Skipping the
+			// call for the empty case left the test reading whatever the
+			// developer or CI had exported, so a shell with
+			// CAIDO_ALLOW_SENSITIVE_HEADERS=1 turned every
+			// redaction-expected case into a failure. "" is not parseable
+			// as a bool, which ParseRaw treats as fail-safe (redact).
+			t.Setenv("CAIDO_ALLOW_SENSITIVE_HEADERS", tt.allow)
 			got := RedactRawHeaders(tt.raw)
 			for _, want := range tt.wantContain {
 				if !strings.Contains(got, want) {

--- a/internal/resources/request_test.go
+++ b/internal/resources/request_test.go
@@ -12,6 +12,10 @@ import (
 // TestReadRequestResourceRedactsSecrets proves the request resource never leaks
 // Authorization/Cookie (request) or Set-Cookie (response) values to the LLM.
 func TestReadRequestResourceRedactsSecrets(t *testing.T) {
+	// Redaction is only ON when CAIDO_ALLOW_SENSITIVE_HEADERS is falsy.
+	// Pin it so this does not depend on the ambient environment.
+	t.Setenv("CAIDO_ALLOW_SENSITIVE_HEADERS", "")
+
 	env := newResourceTestEnv(t)
 
 	reqRaw := base64.StdEncoding.EncodeToString([]byte(

--- a/internal/tools/get_automate_session_test.go
+++ b/internal/tools/get_automate_session_test.go
@@ -14,6 +14,10 @@ import (
 // TestGetAutomateSessionRedactsSecrets proves the fuzzing session's request
 // template never leaks Authorization/Cookie values to the LLM.
 func TestGetAutomateSessionRedactsSecrets(t *testing.T) {
+	// Redaction is only ON when CAIDO_ALLOW_SENSITIVE_HEADERS is falsy.
+	// Pin it so this does not depend on the ambient environment.
+	t.Setenv("CAIDO_ALLOW_SENSITIVE_HEADERS", "")
+
 	rawTemplate := base64.StdEncoding.EncodeToString([]byte(
 		"POST /login HTTP/1.1\r\n" +
 			"Host: example.com\r\n" +


### PR DESCRIPTION
Four test functions across three packages assert that sensitive headers are redacted, but none pinned the environment variable that controls it. Redaction is disabled when `CAIDO_ALLOW_SENSITIVE_HEADERS` parses as true (`internal/httputil/parse.go:36`), so any developer or CI runner with the opt-out exported saw these fail:

```
internal/httputil   TestParseRaw_SensitiveHeaderRedaction
internal/httputil   TestRedactRawHeaders (4 subtests)
internal/resources  TestReadRequestResourceRedactsSecrets
internal/tools      TestGetAutomateSessionRedactsSecrets
```

## Root cause

`redact_test.go` was the clearest case. Its table had an `allow` field documented as `"" leaves it unset`, and the loop only called `t.Setenv` when `allow` was non-empty:

```go
if tt.allow != "" {
    t.Setenv("CAIDO_ALLOW_SENSITIVE_HEADERS", tt.allow)
}
```

So every redaction-expected case read the ambient environment instead of an unset variable. It now always pins the value. `""` is not parseable as a bool, which `ParseRaw` already treats as fail-safe (redact). The field comment is corrected to match.

## Why it matters beyond a red CI line

These are the tests standing behind a credential-redaction guarantee. An exported opt-out silently turned them from "redaction works" into "redaction is off, as configured" -- the assertion stops protecting anything without saying so.

## Verification

Reproduced with `env CAIDO_ALLOW_SENSITIVE_HEADERS=1 go test ./...`, which failed all four before this change and passes after. Also verified with `=true` and with the variable unset, so the fix holds in both polarities rather than trading one failure mode for another.

Gate: `gofmt`, `go vet`, `golangci-lint` 0 issues, `go test -race` all pass.

Found while reviewing #52; independent of that work and touches no overlapping files, so the two can merge in either order.